### PR TITLE
Add dynamic subtitle to vue pages

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,2 +1,3 @@
 # can be 'dev' or 'prod'
 MODE=dev
+VITE_APP_TITLE='Monster DB'

--- a/js/components/move/MonsterListCard.vue
+++ b/js/components/move/MonsterListCard.vue
@@ -10,6 +10,7 @@
                 :illustration-path="monster.illustrationPath"
                 :key="monster.dexId"
             />
+            <span v-if="monsters.length === 0">This move is not learned by any monster.</span>
         </div>
     </div>
 </template>

--- a/js/components/move/StatsCard.vue
+++ b/js/components/move/StatsCard.vue
@@ -17,7 +17,7 @@
                     </tr>
                     <tr class="hover:bg-slate-700">
                         <th class="w-1/2 py-2">Power</th>
-                        <td class="w-1/2 py-2">{{ move.power }}</td>
+                        <td class="w-1/2 py-2">{{ `${move.power ?? '-'}`}}</td>
                     </tr>
                     <tr class="hover:bg-slate-700">
                         <th class="w-1/2 py-2"><abbr title="Power Points">PP</abbr></th>
@@ -27,7 +27,7 @@
                     </tr>
                     <tr class="hover:bg-slate-700">
                         <th class="w-1/2 py-2">Accuracy</th>
-                        <td class="w-1/2 py-2">{{ move.accuracy }}</td>
+                        <td class="w-1/2 py-2">{{ `${move.accuracy !== null ? move.accuracy + '%' : '-'}`}}</td>
                     </tr>
                 </tbody>
             </table>

--- a/js/components/pages/MonsterDetailsPage.vue
+++ b/js/components/pages/MonsterDetailsPage.vue
@@ -45,6 +45,7 @@ onMounted(async () => {
         error.value = 'There was a problem loading the page. Please try again.';
     } finally {
         loaded.value = true;
+        document.title = `${import.meta.env.VITE_APP_TITLE} | ${monster.value.name}`;
     }
 });
 </script>

--- a/js/components/pages/MonsterListPage.vue
+++ b/js/components/pages/MonsterListPage.vue
@@ -60,5 +60,6 @@ try {
     error.value = 'There was a problem loading the page. Please try again.';
 } finally {
     loaded = true;
+    document.title = `${import.meta.env.VITE_APP_TITLE} | Monsters`;
 }
 </script>

--- a/js/components/pages/MoveDetailsPage.vue
+++ b/js/components/pages/MoveDetailsPage.vue
@@ -35,6 +35,7 @@ onMounted(async () => {
         error.value = 'There was a problem loading the page. Please try again.';
     } finally {
         loaded.value = true;
+        document.title = `${import.meta.env.VITE_APP_TITLE} | ${move.value.name}`;
     }
 });
 </script>

--- a/js/components/pages/MoveListPage.vue
+++ b/js/components/pages/MoveListPage.vue
@@ -5,7 +5,7 @@
     <template v-else>
         <div v-if="!loaded">Loading..</div>
         <div v-else class="flex flex-wrap mt-4 px-5">
-            <MoveListCard class="w-full" :moves="moves" hide-requisite />
+            <MoveListCard class="w-full mb-5" :moves="moves" hide-requisite />
         </div>
     </template>
 </template>
@@ -32,6 +32,7 @@ onMounted(async () => {
         error.value = 'There was a problem loading the page. Please try again.';
     } finally {
         loaded.value = true;
+        document.title = `${import.meta.env.VITE_APP_TITLE} | Moves`;
     }
 });
 </script>


### PR DESCRIPTION
- Introduces a new env var, `VITE_APP_TITLE` to set the base title
- Fixes defects in the moves list and moves details pages