### PR TITLE
Add mp4 versions of moves

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.flac filter=lfs diff=lfs merge=lfs -text
 *.webm filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/js/components/move/StatsCard.vue
+++ b/js/components/move/StatsCard.vue
@@ -1,8 +1,13 @@
 <template>
     <div class="w-auto md:mx-5 rounded bg-slate-600 p-2">
         <div class="m-2 text-center text-2xl font-bold">
-            <video muted autoplay loop class="w-full">
-                <source :src="move.animationPath" type="video/webm" />
+            <video muted autoplay loop playsinline class="w-full">
+                <source
+                    v-for="(animation, key) in move.animations"
+                    :src="animation.path"
+                    :type="animation.mimeType"
+                    :key="key"
+                />
             </video>
             {{ move.name }}
         </div>

--- a/public/assets/moves/animations/absorb.mp4
+++ b/public/assets/moves/animations/absorb.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbae5ed9cdedbfb2c563c148b5ddf636d0dda349f5f8461ba55cc430bd18126d
+size 42372

--- a/public/assets/moves/animations/acid.mp4
+++ b/public/assets/moves/animations/acid.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3885e3054d85f92a1fdfcf9fc5194dd24c919f196b39d5b23cc1045f9e36d1a0
+size 23726

--- a/public/assets/moves/animations/acidarmor.mp4
+++ b/public/assets/moves/animations/acidarmor.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79fa3d5467447524e10040119c7951188eeb7cd5df60d54f65d6cd96c1a3f77b
+size 18877

--- a/public/assets/moves/animations/agility.mp4
+++ b/public/assets/moves/animations/agility.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b87faf0f9278058f071a5f49da59bc427aa03a23bfd913a821818ea1c145d59c
+size 19690

--- a/public/assets/moves/animations/amnesia.mp4
+++ b/public/assets/moves/animations/amnesia.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acf18993a92f44d4625a6265246248900a739c40b99d0264a6b3cf9f34d9ab71
+size 20917

--- a/public/assets/moves/animations/aurorabeam.mp4
+++ b/public/assets/moves/animations/aurorabeam.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eaf587cb63487bed8b41123df90c5720d1ce40d587caa48c398472acd0b67fa5
+size 20739

--- a/public/assets/moves/animations/barrage.mp4
+++ b/public/assets/moves/animations/barrage.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:476ffa0f0a62868a9c64ec690eea53edd36813fda7d7c99ee3a6b40186a719e5
+size 37066

--- a/public/assets/moves/animations/barrier.mp4
+++ b/public/assets/moves/animations/barrier.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ebb80c647381ab9de89b7c2e751857b78c0ab7330f160b6d1fdf690e4068a4e
+size 27775

--- a/public/assets/moves/animations/bide.mp4
+++ b/public/assets/moves/animations/bide.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9f5b87a7cd2a0fcd9afce49aa5a63c2c969a7de41e9e52695e0e43997d089b0
+size 90353

--- a/public/assets/moves/animations/bind.mp4
+++ b/public/assets/moves/animations/bind.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc5f3aa6c1ff2cfd9af9d5c2bf050446e6a5f891e95ac3e9f97240d28777ce8c
+size 19270

--- a/public/assets/moves/animations/bite.mp4
+++ b/public/assets/moves/animations/bite.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02c5bacb36cfcde4b3108b36a343c3d54f6d24008c03eac8a212ce602f8d5c99
+size 14742

--- a/public/assets/moves/animations/blizzard.mp4
+++ b/public/assets/moves/animations/blizzard.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:604984073175fda23586f2ba2ab5cc50b517eeac3112b83daf65116313f2b693
+size 83545

--- a/public/assets/moves/animations/bodyslam.mp4
+++ b/public/assets/moves/animations/bodyslam.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f507f634db35f354b74b034ebf83b2e8042a06808dde58ed6c15e58c5954f88e
+size 24460

--- a/public/assets/moves/animations/boneclub.mp4
+++ b/public/assets/moves/animations/boneclub.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f053a1828cc2b3abbddd3bcaee824fb9644655b7f68fb66f17dccf3fcca749b
+size 13912

--- a/public/assets/moves/animations/bonemerang.mp4
+++ b/public/assets/moves/animations/bonemerang.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49d9a2e818dd251e053b9285eac383c6ab0c1aa5b45a2ace98a3efec486cb5b6
+size 22004

--- a/public/assets/moves/animations/bubble.mp4
+++ b/public/assets/moves/animations/bubble.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc540efc850eaa8e8182130574a68d65b434b4328cf1d18da368858ab0e7cc42
+size 26916

--- a/public/assets/moves/animations/bubblebeam.mp4
+++ b/public/assets/moves/animations/bubblebeam.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dc3773919aa1638cb744ce7f23b735b74e9117c2d95681e18b57bf450a845a0
+size 46406

--- a/public/assets/moves/animations/clamp.mp4
+++ b/public/assets/moves/animations/clamp.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c613aafd01f15e68a954520dfea9e6d149de371cf4d4a2a86abce84ab2c204e
+size 22509

--- a/public/assets/moves/animations/cometpunch.mp4
+++ b/public/assets/moves/animations/cometpunch.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efa8b5831e25ca64e19fb9153eed5689dffe97a236dc21d3194fb7670416ba9b
+size 20399

--- a/public/assets/moves/animations/confuseray.mp4
+++ b/public/assets/moves/animations/confuseray.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f2d7ce25d25515c87940d540e9edbb33bcc389aa711ed6a8bbb7646780ec25d
+size 31091

--- a/public/assets/moves/animations/confusion.mp4
+++ b/public/assets/moves/animations/confusion.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:592199ae414e4dde1699e26006c15e512399e50c176893bb0d5b6f8f83c9f217
+size 40490

--- a/public/assets/moves/animations/constrict.mp4
+++ b/public/assets/moves/animations/constrict.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0da17cbf0a32df4b0217d28dd6ff64880a4d302c15532af3cf7a3870e44692c
+size 21029

--- a/public/assets/moves/animations/conversion.mp4
+++ b/public/assets/moves/animations/conversion.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef6a257910b80f9ccb838c76343f50c28128ef39315ab21b8f77199c0c84e438
+size 33270

--- a/public/assets/moves/animations/counter.mp4
+++ b/public/assets/moves/animations/counter.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed9bbf2496fb726b7de8c4ce1f74f294683d6cfbc2bc99dab495bdf23e66be6d
+size 27487

--- a/public/assets/moves/animations/crabhammer.mp4
+++ b/public/assets/moves/animations/crabhammer.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03528d868f29ae8376092e743a86dc84740708eb8848d2789c230269b3bd7805
+size 23824

--- a/public/assets/moves/animations/cut.mp4
+++ b/public/assets/moves/animations/cut.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5ae27f915d99108df0157865a226d083ecbcdcae8ed1a0d966f8073ebe64e5f
+size 24336

--- a/public/assets/moves/animations/defensecurl.mp4
+++ b/public/assets/moves/animations/defensecurl.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f79ef054008810a1d469e63bbb59b22cfef1dd36423ecab83fdb484655af1520
+size 26811

--- a/public/assets/moves/animations/dig.mp4
+++ b/public/assets/moves/animations/dig.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:261a688579ad8162ab4b14d88bd160f2650381c8d9701e85a36f202b21617bc1
+size 32348

--- a/public/assets/moves/animations/disable.mp4
+++ b/public/assets/moves/animations/disable.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b0891dfc8cbbe91454594738010b9f2270272d8103a6230bc7e0f4e86d19b1d
+size 31506

--- a/public/assets/moves/animations/dizzypunch.mp4
+++ b/public/assets/moves/animations/dizzypunch.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19791133f5532f25bc8724c36ec54913791e52903073148a324cfe8cc0dcf8a3
+size 28553

--- a/public/assets/moves/animations/doubleedge.mp4
+++ b/public/assets/moves/animations/doubleedge.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4752b1b880536a34fe2c7dec75c5390cb287f8a460b77a46ca3d40250f70658d
+size 37115

--- a/public/assets/moves/animations/doublekick.mp4
+++ b/public/assets/moves/animations/doublekick.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34a16a3c0af9e1322c1dadbe0e2f7f5290b31aeced44e9aadab834f6d537cc0b
+size 20593

--- a/public/assets/moves/animations/doubleslap.mp4
+++ b/public/assets/moves/animations/doubleslap.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd7ef244aa7db4c87869fc1234d5275c7f0b0ad0cdfcecf414c0287ac4565f5b
+size 19400

--- a/public/assets/moves/animations/doubleteam.mp4
+++ b/public/assets/moves/animations/doubleteam.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d53e79cf34d54abe23e66c8572443a6e59959f8345d76daef92df37a1e5129e9
+size 33691

--- a/public/assets/moves/animations/dragonrage.mp4
+++ b/public/assets/moves/animations/dragonrage.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab3cf67740c2e427a65566d595b3fc90dbf874733c8ee91e1997c7aa86cf51c1
+size 26025

--- a/public/assets/moves/animations/dreameater.mp4
+++ b/public/assets/moves/animations/dreameater.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:802adc911f6c972ca20de0bb35df80bc8259c7b4777f348ba9bcab503b3661a7
+size 58382

--- a/public/assets/moves/animations/drillpeck.mp4
+++ b/public/assets/moves/animations/drillpeck.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0e35bf0089fceefa273864c795232108e4a47a30e649ef7a26f88eaa98c8cbb
+size 21455

--- a/public/assets/moves/animations/earthquake.mp4
+++ b/public/assets/moves/animations/earthquake.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e79b2a2346a28c1f8878a2cd700abd769833805df299a695ed2fc157110d0e8
+size 35394

--- a/public/assets/moves/animations/eggbomb.mp4
+++ b/public/assets/moves/animations/eggbomb.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f855ae02cc454f0e86af7727ff758070c3e9602de7fa95218814dd2f284662d2
+size 23909

--- a/public/assets/moves/animations/ember.mp4
+++ b/public/assets/moves/animations/ember.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02778b9120f1bbf340d74d995862db5744959d1784db313a10185ce3c9f2733d
+size 22281

--- a/public/assets/moves/animations/explosion.mp4
+++ b/public/assets/moves/animations/explosion.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fa80d4c4fc85bfd41965fb8dd1a8233547efa07f2941c3595f8b3e149009f3d
+size 93896

--- a/public/assets/moves/animations/fireblast.mp4
+++ b/public/assets/moves/animations/fireblast.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:675221843b73a1c77395ef761f4196c5f336bb2f2db7bfa0d8468442da5cdad3
+size 27847

--- a/public/assets/moves/animations/firepunch.mp4
+++ b/public/assets/moves/animations/firepunch.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dca8428cbea0841f4f71cff1750e65de58426d32bb8c6c59d5c00866bdea28b
+size 24175

--- a/public/assets/moves/animations/firespin.mp4
+++ b/public/assets/moves/animations/firespin.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd5918586a819006a0bb51296db2eaf3e246748fd78d2651cdcdd176f2599808
+size 24609

--- a/public/assets/moves/animations/fissure.mp4
+++ b/public/assets/moves/animations/fissure.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87c236a8add41f2fc090ede8e68efa4ef3bb89cbe38ca751a2b40d6a7d63a971
+size 48851

--- a/public/assets/moves/animations/flamethrower.mp4
+++ b/public/assets/moves/animations/flamethrower.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1cd72be42828d22c2ce90eb09d815950af79f15c94c17203c2069c3d61d2f81
+size 24571

--- a/public/assets/moves/animations/flash.mp4
+++ b/public/assets/moves/animations/flash.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cccec2080b4ca3a1e0709b557bc9c6d6bbdfcfaf029021c239c88fc5a98c9c45
+size 26303

--- a/public/assets/moves/animations/fly.mp4
+++ b/public/assets/moves/animations/fly.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b199e0eeab251522fc3a65b9d251308e19ae6b1243c3b504ea5057d92cf3aa80
+size 38652

--- a/public/assets/moves/animations/focusenergy.mp4
+++ b/public/assets/moves/animations/focusenergy.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8d81b147bf8230be7690937d4fe23a4a5015a50e30a01e015bc41ae65b5e063
+size 27238

--- a/public/assets/moves/animations/furyattack.mp4
+++ b/public/assets/moves/animations/furyattack.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:737c09e050762929fde55e2059d8916f51629dcb733491f944c50c4fff34854f
+size 21327

--- a/public/assets/moves/animations/furyswipes.mp4
+++ b/public/assets/moves/animations/furyswipes.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b812f9003d480f59325bdc9793b5186adaa18ed72e97ab8522d06ee0aa66662f
+size 19480

--- a/public/assets/moves/animations/glare.mp4
+++ b/public/assets/moves/animations/glare.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:022a26aa6ad4270cf8c0d93f3255e33f5f7d3c6e238d7b77fe67cb23908f7c1a
+size 30200

--- a/public/assets/moves/animations/growl.mp4
+++ b/public/assets/moves/animations/growl.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1e4512d284a30ca450091cdec955dce9ff3e46dc9de0d4981f16b57b89f1d0a
+size 45418

--- a/public/assets/moves/animations/growth.mp4
+++ b/public/assets/moves/animations/growth.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:421fb1cf2b65cc993ea596b1a81b6359083b79a468b9d5be1f9662afe3e0b93c
+size 28035

--- a/public/assets/moves/animations/guillotine.mp4
+++ b/public/assets/moves/animations/guillotine.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d398ba704d20fde5efbdca477a075f95d836f5007ff679c581ff6bb44ce971ac
+size 56960

--- a/public/assets/moves/animations/gust.mp4
+++ b/public/assets/moves/animations/gust.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8f154de4b389bafcb4bdd9b34dee2118d2922bca318442796597f22e45606eb
+size 23185

--- a/public/assets/moves/animations/harden.mp4
+++ b/public/assets/moves/animations/harden.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:960b7aa29569132e12c1c5cd894a07de93baa548a9d85239439961d678e369e7
+size 24304

--- a/public/assets/moves/animations/haze.mp4
+++ b/public/assets/moves/animations/haze.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee6a2d57b91478f87634bf8a4f2f8141c6c2f394f00161174c85c4fa64b56132
+size 89781

--- a/public/assets/moves/animations/headbutt.mp4
+++ b/public/assets/moves/animations/headbutt.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a15e2adc9eda29947de358d4ae90808bd6d456b63abb720093a84be39f9e7e1f
+size 22653

--- a/public/assets/moves/animations/hijumpkick.mp4
+++ b/public/assets/moves/animations/hijumpkick.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08e85298cf2dc4375d0459d06a85799dd685757ab04716ecef64a64be6bae5b2
+size 19627

--- a/public/assets/moves/animations/hornattack.mp4
+++ b/public/assets/moves/animations/hornattack.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f43593753d599ff060d4416f67188423414782ea53555bccac889fc0c2cece2
+size 23570

--- a/public/assets/moves/animations/horndrill.mp4
+++ b/public/assets/moves/animations/horndrill.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d1c2bc0669515b356553e458f159fcf1aad6343d308ce4d2efcccd5c5e12e1d
+size 23958

--- a/public/assets/moves/animations/hydropump.mp4
+++ b/public/assets/moves/animations/hydropump.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da11fc3c45117ea4e103bbcaff6e894f7515c4fc073a49337a139e864e7dcdc7
+size 36277

--- a/public/assets/moves/animations/hyperbeam.mp4
+++ b/public/assets/moves/animations/hyperbeam.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5667dee5f8c62f768884e9b11cce34b8c27940ac8cf37d11dc51241471538bf8
+size 57728

--- a/public/assets/moves/animations/hyperfang.mp4
+++ b/public/assets/moves/animations/hyperfang.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:775d0f9dbe55e63712cab9ddf0cd675fb6fe65a228946efcb79d5708c749b484
+size 14409

--- a/public/assets/moves/animations/hypnosis.mp4
+++ b/public/assets/moves/animations/hypnosis.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c6b93fe7abe32ccc3c6a4723eae44b7f98f0a4f90c42f49ae96db3a31b163ee
+size 48499

--- a/public/assets/moves/animations/ice beam.mp4
+++ b/public/assets/moves/animations/ice beam.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81addf90fe518af4d5570abdc152ac59f589335d0fbbf22542dda747fac71afe
+size 23004

--- a/public/assets/moves/animations/icepunch.mp4
+++ b/public/assets/moves/animations/icepunch.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:128a23481b6339059dfdd4827c7937348cf0c39f628a2dfcd881584c709aaf78
+size 23827

--- a/public/assets/moves/animations/jumpkick.mp4
+++ b/public/assets/moves/animations/jumpkick.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16e00ed1e099e65c6078d6c2e46df067c83851aa79e69cc4cad8a60625b80e1f
+size 14976

--- a/public/assets/moves/animations/karatechop.mp4
+++ b/public/assets/moves/animations/karatechop.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53a8763d96d7198e11d0c73e7051a23aa12a07e51eedc32ef02e0568968144e3
+size 22352

--- a/public/assets/moves/animations/kinesis.mp4
+++ b/public/assets/moves/animations/kinesis.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:868da4a80b7bbf858273630eac50e46271ed9af865844fd2ec1555d4d42152b1
+size 22230

--- a/public/assets/moves/animations/leechlife.mp4
+++ b/public/assets/moves/animations/leechlife.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf4c14c7a09702194241f97a591c9108320b984a8c27792f3c21e6cdb0fd377e
+size 54779

--- a/public/assets/moves/animations/leechseed.mp4
+++ b/public/assets/moves/animations/leechseed.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:626689ccea6b5081e9f172e343cfc13dc5ae9b084c1471d692723dee362a9e63
+size 23619

--- a/public/assets/moves/animations/leer.mp4
+++ b/public/assets/moves/animations/leer.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a785f81e7b1338d031ec912892f711a921aea9ce4472194095a77936304c7bef
+size 29409

--- a/public/assets/moves/animations/lick.mp4
+++ b/public/assets/moves/animations/lick.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95d7e21b163289e8afbb64a06b93946c2116106ea70e4fda3ee68472cd514741
+size 17763

--- a/public/assets/moves/animations/lightscreen.mp4
+++ b/public/assets/moves/animations/lightscreen.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e924a2419e9b6d9cb280f0b8083d6110070abdeb96e1aa5f5943c3e3db86195a
+size 31139

--- a/public/assets/moves/animations/lovelykiss.mp4
+++ b/public/assets/moves/animations/lovelykiss.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bb10f6470a152224027c59b8f917ac2669226bdbd7603b7b6d14c0d6347e6e1
+size 21694

--- a/public/assets/moves/animations/lowkick.mp4
+++ b/public/assets/moves/animations/lowkick.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1be8e55ad3eab422cc02ea73278807794365c867a4b8eb21c53737876b9845ca
+size 20447

--- a/public/assets/moves/animations/meditate.mp4
+++ b/public/assets/moves/animations/meditate.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab5862128f0f67b2bf7f82d15d9cdef10a6d2617f61ed3eaa886746fd1268f0b
+size 24056

--- a/public/assets/moves/animations/megadrain.mp4
+++ b/public/assets/moves/animations/megadrain.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096c6ccd4c80a0d1a5b15bd0ebcced6fded64da773d7c73bd3383a424986966f
+size 49906

--- a/public/assets/moves/animations/megakick.mp4
+++ b/public/assets/moves/animations/megakick.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98705e1de2e1719b3f189911260f4d2090965c15387bf9db2ad5e52c6c595493
+size 41159

--- a/public/assets/moves/animations/megapunch.mp4
+++ b/public/assets/moves/animations/megapunch.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc79655ac8ecedcf88c1fdf20898293a617394dbad49e74b084a0595e6d59b34
+size 39655

--- a/public/assets/moves/animations/metronome.mp4
+++ b/public/assets/moves/animations/metronome.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5bf1215bf89152e5fa3f63a77a3ef8acb712222eae60880336a780cd10225a9
+size 107435

--- a/public/assets/moves/animations/mimic.mp4
+++ b/public/assets/moves/animations/mimic.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58f4b5033b6903963ba2026f4cd3c749f05c0bf881a462f9c345a72f53f50ffc
+size 30485

--- a/public/assets/moves/animations/minimize.mp4
+++ b/public/assets/moves/animations/minimize.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a890af4b2e513938b2b3645ae96795ba7b0a98aa63f74159730f2dfa7218d0cc
+size 30288

--- a/public/assets/moves/animations/mirrormove.mp4
+++ b/public/assets/moves/animations/mirrormove.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b278e05afa0b0bdfd8bf8323adf1972fe0287fd4f056a6e68b5f54b5387cf443
+size 25750

--- a/public/assets/moves/animations/mist.mp4
+++ b/public/assets/moves/animations/mist.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2df62bfe1587e34a4e2c35f1e957ba837a4ca5aadb174d1667cbcffda7e9b729
+size 98048

--- a/public/assets/moves/animations/nightshade.mp4
+++ b/public/assets/moves/animations/nightshade.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb78ed0e192aa3b06de57a37e95e08b104d4fb735248731e7dc7638615450e0f
+size 201605

--- a/public/assets/moves/animations/payday.mp4
+++ b/public/assets/moves/animations/payday.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:132ce021c5aa78f1863b2cc22d7624f40242246074c28ce675c3af500842d32f
+size 28967

--- a/public/assets/moves/animations/peck.mp4
+++ b/public/assets/moves/animations/peck.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19d4e45bcd474f6e6c900a56da313fe42dbcc55ad30a0d809458dd658c3ada24
+size 21150

--- a/public/assets/moves/animations/petaldance.mp4
+++ b/public/assets/moves/animations/petaldance.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6cd833733e508baeef95ec43dae38f6b80a1bc9442bcbea4e48870275d2dc80
+size 51246

--- a/public/assets/moves/animations/pinmissile.mp4
+++ b/public/assets/moves/animations/pinmissile.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e181804e8830b4498c3006eb13e487d63621051c8f91f97b7823876765f2c947
+size 18267

--- a/public/assets/moves/animations/poisongas.mp4
+++ b/public/assets/moves/animations/poisongas.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:190e18355422e4d131e1d8d4e5f333a855fd0415bc7735ed59d62a01616b429c
+size 22629

--- a/public/assets/moves/animations/poisonpowder.mp4
+++ b/public/assets/moves/animations/poisonpowder.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b98614d3febb4387d208aac17a85229f858b04e1ca3485e1bc0dd85aceb7b779
+size 19969

--- a/public/assets/moves/animations/poisonsting.mp4
+++ b/public/assets/moves/animations/poisonsting.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f2c54b0015779d942ace37f0ffa03e0e3fe41fb9c03f7c663297a4b32bc4794
+size 22096

--- a/public/assets/moves/animations/pound.mp4
+++ b/public/assets/moves/animations/pound.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6cc7728ffd62f747fef58976eb5243d79a5a6d717d2b71614e730470e071ad5
+size 18986

--- a/public/assets/moves/animations/psybeam.mp4
+++ b/public/assets/moves/animations/psybeam.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b7fe2d71162b989210b9d2c19c05f5abefffea4eddbea046783b7b4b48c7abe
+size 54386

--- a/public/assets/moves/animations/psychic.mp4
+++ b/public/assets/moves/animations/psychic.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b868074c67157775574e5aab37b081eb335b4cbc5f3d72dd5c0e96e25ab8494
+size 231731

--- a/public/assets/moves/animations/psywave.mp4
+++ b/public/assets/moves/animations/psywave.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5672f4c1fe2fa29a4469e52a94c7b58347a62dd92f5fbae16dad1de540d99015
+size 198623

--- a/public/assets/moves/animations/quickattack.mp4
+++ b/public/assets/moves/animations/quickattack.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ae8572c7251e27892113daddb33ab47d48e4a0395f55eca8d4a7403b72e5b4
+size 23757

--- a/public/assets/moves/animations/rage.mp4
+++ b/public/assets/moves/animations/rage.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11e92bf65013b597723f17ab3c91d16f7589903b538d8cc5bd270095752b20cf
+size 22985

--- a/public/assets/moves/animations/razorleaf.mp4
+++ b/public/assets/moves/animations/razorleaf.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48c9e121bbb02e1c76bd30f166e3c905355b658093eb403598599959ad14f4c9
+size 43609

--- a/public/assets/moves/animations/razorwind.mp4
+++ b/public/assets/moves/animations/razorwind.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5a65d92d499130d7c77093f3010f49f6c20729c90d3d99e4fe7942165e8905b
+size 58004

--- a/public/assets/moves/animations/recover.mp4
+++ b/public/assets/moves/animations/recover.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0059bffd5074e2c6f10d98c2f40440f213365fc87fa9f3fab612a479f8783ea1
+size 33329

--- a/public/assets/moves/animations/reflect.mp4
+++ b/public/assets/moves/animations/reflect.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fb2f099402e4416fd87e264da51f5b85799ccbc95a85ebdb4d67974e0098443
+size 94338

--- a/public/assets/moves/animations/rest.mp4
+++ b/public/assets/moves/animations/rest.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:896e238b1fb1a325ca34e34be048cfb826371585be98b336367343d5cf2e2d46
+size 24170

--- a/public/assets/moves/animations/roar.mp4
+++ b/public/assets/moves/animations/roar.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04faae4fabc5d508600d95014f00100e08d8a7fdb683215ce7613062dd6e3a55
+size 23513

--- a/public/assets/moves/animations/rockslide.mp4
+++ b/public/assets/moves/animations/rockslide.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1630c3007ea9009f9c05c0e1ce90a02db562259fdcd6034c153191d74b098787
+size 56975

--- a/public/assets/moves/animations/rockthrow.mp4
+++ b/public/assets/moves/animations/rockthrow.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3899a68f3acadbff5715d77579414e2a53bee45b69b52771cfaf56ca93463de5
+size 22573

--- a/public/assets/moves/animations/rollingkick.mp4
+++ b/public/assets/moves/animations/rollingkick.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4861cfc64800059e977720998cc1547f238cc4bf9e12d032d25a1875763b747
+size 24150

--- a/public/assets/moves/animations/sandattack.mp4
+++ b/public/assets/moves/animations/sandattack.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0459351c51aff9b73e22af04cc521c9c19f17bab4c780145a38108c5d9beb9e6
+size 20108

--- a/public/assets/moves/animations/scratch.mp4
+++ b/public/assets/moves/animations/scratch.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb290a2e5684d3a7b7c86cea0a17cef92471e185115e4be74c6683ae71adef82
+size 25563

--- a/public/assets/moves/animations/screech.mp4
+++ b/public/assets/moves/animations/screech.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:824372ef9159b0e5687506822301cdcc5246ba2ec5792a9d8a8d85924e0f5032
+size 26154

--- a/public/assets/moves/animations/seismictoss.mp4
+++ b/public/assets/moves/animations/seismictoss.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8a24cb3e64fed533ef045330e8ce66223477d8067d3483dda9fc1a4f2a3e1ad
+size 28537

--- a/public/assets/moves/animations/selfdestruct.mp4
+++ b/public/assets/moves/animations/selfdestruct.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78a46004619de78a0101a45d91e567497dc6d682c29db9904a05a5663757caf8
+size 92222

--- a/public/assets/moves/animations/sharpen.mp4
+++ b/public/assets/moves/animations/sharpen.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9c16720fb15fd75df73759d041500641f0f6f2d112811beb1777d91dccd57f2
+size 24773

--- a/public/assets/moves/animations/sing.mp4
+++ b/public/assets/moves/animations/sing.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99574b4773e1887e14d5c9af3ff11852f799aa6e6819e4512716db9d5ada12d5
+size 35821

--- a/public/assets/moves/animations/skullbash.mp4
+++ b/public/assets/moves/animations/skullbash.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:995617e729e04f015f9a869f8cf2fe059e52f9ffa8c74555b8cf56104e64bc7d
+size 59230

--- a/public/assets/moves/animations/skyattack.mp4
+++ b/public/assets/moves/animations/skyattack.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:254180e73398133832dda0eb3f85575548760f77550ed2453d9f026231b31b1e
+size 62064

--- a/public/assets/moves/animations/slam.mp4
+++ b/public/assets/moves/animations/slam.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e6c1c910c92aa0015cd1621c45540cd98b3460f2e13132846f6cd439cdc25ea
+size 21424

--- a/public/assets/moves/animations/slash.mp4
+++ b/public/assets/moves/animations/slash.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f37b43de891035da45af9c36d99a91f20e3cb0cb283e3a70709bf87507e02456
+size 24078

--- a/public/assets/moves/animations/sleeppowder.mp4
+++ b/public/assets/moves/animations/sleeppowder.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f3b9fa2e2d667bdc9e17c5a1572c281ec8bf761292084ef3294a913cd008ac4
+size 24786

--- a/public/assets/moves/animations/sludge.mp4
+++ b/public/assets/moves/animations/sludge.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de66039b31e8754da1be4f291e822c1812e061180ccd68b240f0cbd117d2ad7a
+size 22285

--- a/public/assets/moves/animations/smog.mp4
+++ b/public/assets/moves/animations/smog.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e5f2ac44dc4a9de9af9431579ad35ef3e67929578a1a65c74651966fccbe34e
+size 23582

--- a/public/assets/moves/animations/smokescreen.mp4
+++ b/public/assets/moves/animations/smokescreen.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c898ec2651557e52ef36bcdfed9fbe19a49e6e13959d333542134947d8d1e184
+size 35613

--- a/public/assets/moves/animations/softboiled.mp4
+++ b/public/assets/moves/animations/softboiled.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d593bba42044a425bc5d5baf82c0ffa5f23a9a5dd38da8c504c73c72d53b01
+size 36461

--- a/public/assets/moves/animations/solarbeam.mp4
+++ b/public/assets/moves/animations/solarbeam.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60eb510cd0ac42514c8fc2f4e34f92ad9541aa778116d54cf6032f5ee3ac6056
+size 62212

--- a/public/assets/moves/animations/sonicboom.mp4
+++ b/public/assets/moves/animations/sonicboom.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:837ecb07aba6b1eec2c1f0dca12329127614e1f2cd6d7268e90d8ed63abd3eb0
+size 26264

--- a/public/assets/moves/animations/spikecannon.mp4
+++ b/public/assets/moves/animations/spikecannon.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b692f37241377b705aa32ab60b82f4a3dbb2448e78dc3ec493ec125fe6ab768
+size 21947

--- a/public/assets/moves/animations/splash.mp4
+++ b/public/assets/moves/animations/splash.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edbed96f3b5c38c41e899e1b72413304f538a524c49d7e59b546f0208af8a0f4
+size 17174

--- a/public/assets/moves/animations/spore.mp4
+++ b/public/assets/moves/animations/spore.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:301abcb10911e3ba2be8c2fc32172e058d4cb4459b9072b73c7589ab98a965f3
+size 81752

--- a/public/assets/moves/animations/stomp.mp4
+++ b/public/assets/moves/animations/stomp.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1633cfe059a2ef7f47b43d4a6267ec097e2b3bc53f08012d62a8c460f454ae21
+size 17512

--- a/public/assets/moves/animations/strength.mp4
+++ b/public/assets/moves/animations/strength.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab7e8f4df84358064f3af2d6f9219233816a0d0d73d40d76af99c76d682ad02b
+size 22457

--- a/public/assets/moves/animations/stringshot.mp4
+++ b/public/assets/moves/animations/stringshot.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f440ec90c9093df10bce87e5c09875e68e897d9be686be603398a8b201cc01e
+size 23185

--- a/public/assets/moves/animations/struggle.mp4
+++ b/public/assets/moves/animations/struggle.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de8ed05a946b93766d5e140865d466754e8094d124082444d422fca3cb0277d2
+size 28086

--- a/public/assets/moves/animations/stunspore.mp4
+++ b/public/assets/moves/animations/stunspore.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79fff7cb863230de5e3af1546b73dae5c24d1191cb27895965041d36eca306dc
+size 28150

--- a/public/assets/moves/animations/submission.mp4
+++ b/public/assets/moves/animations/submission.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24be5569a8a2879b300dcc9bff231e9533f9138b6a4ff1886b853d49b844c3c8
+size 36093

--- a/public/assets/moves/animations/substitute.mp4
+++ b/public/assets/moves/animations/substitute.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b29e56ad3326a6ec2251e6c01f3a4c8c94f5493cae5866045262715da32f74a
+size 53881

--- a/public/assets/moves/animations/superfang.mp4
+++ b/public/assets/moves/animations/superfang.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6e934c6aaa79832ac290c8450579a442dc9ae7a0b585ca4bdb97287898f4214
+size 24609

--- a/public/assets/moves/animations/supersonic.mp4
+++ b/public/assets/moves/animations/supersonic.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:defe95166cbe900d08e982105af53bf8ffcdc740ea82db5c7414807317cd8b5a
+size 24042

--- a/public/assets/moves/animations/surf.mp4
+++ b/public/assets/moves/animations/surf.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9edd51d163bfaf5b7d40ac3cd18123dd26071b1f4866a1aadc465692deac6525
+size 102001

--- a/public/assets/moves/animations/swift.mp4
+++ b/public/assets/moves/animations/swift.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9f271ca45413463c29148de5226ae486fb430f62e696b8ad0a2ba9154b2b89f
+size 22269

--- a/public/assets/moves/animations/swordsdance.mp4
+++ b/public/assets/moves/animations/swordsdance.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6881a2c793dd7ffa3937d899092676778739797cfcad49e9ba50276e1a843fa7
+size 26379

--- a/public/assets/moves/animations/tackle.mp4
+++ b/public/assets/moves/animations/tackle.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2c31f37cb5f2171edb80c51ed35fcaf5b701c99250a91051737a3eae540cc27
+size 11849

--- a/public/assets/moves/animations/tailwhip.mp4
+++ b/public/assets/moves/animations/tailwhip.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a748519093ddd8c54cc749dec85f1a217ef9572813863081daf958d8d277110
+size 21355

--- a/public/assets/moves/animations/takedown.mp4
+++ b/public/assets/moves/animations/takedown.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27e3b0381dd00a3159d8e241043ffc7095ced97e0534a096290bb3c7e7e2461e
+size 31749

--- a/public/assets/moves/animations/teleport.mp4
+++ b/public/assets/moves/animations/teleport.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50443d444ed834ea24728eaca6cbf820cbd34780306a4620511d011b2cf68611
+size 19918

--- a/public/assets/moves/animations/thrash.mp4
+++ b/public/assets/moves/animations/thrash.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41650243f52f78db0cb672ce95275075a68374d59a35c7f8f9334d9e1f406bb8
+size 43426

--- a/public/assets/moves/animations/thunder.mp4
+++ b/public/assets/moves/animations/thunder.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2b3eab274a4677539fb22adb247baeebc14e219927d6f88115a60ca21a47373
+size 46720

--- a/public/assets/moves/animations/thunderbolt.mp4
+++ b/public/assets/moves/animations/thunderbolt.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84c434421b7768031df3a0a7ce66ebac3d16c504c842a828d1069905ac819476
+size 72491

--- a/public/assets/moves/animations/thunderpunch.mp4
+++ b/public/assets/moves/animations/thunderpunch.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5694685eecafe00b028e1129ef31ce650feeb1804e96ff749d341312259469f
+size 32866

--- a/public/assets/moves/animations/thundershock.mp4
+++ b/public/assets/moves/animations/thundershock.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f12ef33656c9fb91d722616a3dfbd4928c5c61769a84dd560fbdd41733419ec7
+size 24394

--- a/public/assets/moves/animations/thunderwave.mp4
+++ b/public/assets/moves/animations/thunderwave.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75aa155614e1136bc702ad42e5175827a618ae1f71d36a8094762da8e8005943
+size 29839

--- a/public/assets/moves/animations/toxic.mp4
+++ b/public/assets/moves/animations/toxic.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06b71140f6b63ecd8c9dd37ae96c63f6e0c66b558796e3561625f8924cceabdb
+size 94719

--- a/public/assets/moves/animations/transform.mp4
+++ b/public/assets/moves/animations/transform.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68c9422876efca5091f0c377dca7e348dabd371d93efe8256cdcef2465000bb9
+size 24213

--- a/public/assets/moves/animations/triattack.mp4
+++ b/public/assets/moves/animations/triattack.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c13bfa32601badf1759b7cd315e6d4462d3f5ce634db356f0d76a34a622b50e
+size 42889

--- a/public/assets/moves/animations/twineedle.mp4
+++ b/public/assets/moves/animations/twineedle.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a722d02033d44efab28c7193d090c05130bcebe3a81df0d4b2b180daf8a7c694
+size 20348

--- a/public/assets/moves/animations/vicegrip.mp4
+++ b/public/assets/moves/animations/vicegrip.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71172d50ad3704bd5d40b328c96e60a57fae6e0babffd25bd3bc84834e2f6ba7
+size 21306

--- a/public/assets/moves/animations/vinewhip.mp4
+++ b/public/assets/moves/animations/vinewhip.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8f9241ccbe0f6c7a3695f17a3ed91ae1dadce6b1d164de8e768590760fba839
+size 23503

--- a/public/assets/moves/animations/waterfall.mp4
+++ b/public/assets/moves/animations/waterfall.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:059bd7a20d0c4c3983b980958013a6e88f5ca6f6c95170d730c6040c418eeb31
+size 30579

--- a/public/assets/moves/animations/watergun.mp4
+++ b/public/assets/moves/animations/watergun.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7285bf4c0ed73ba2edfba6d4ad3ca5c9830c6ba080a6f23d9f52805e7f771718
+size 24647

--- a/public/assets/moves/animations/whirlwind.mp4
+++ b/public/assets/moves/animations/whirlwind.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c735325c7e506f560d5b545b1552407ebe7f25f399b3458f51e059897daeb1e
+size 23468

--- a/public/assets/moves/animations/wingattack.mp4
+++ b/public/assets/moves/animations/wingattack.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c3202ef6989a8a73c8efc396cbacdf044008a824d85804b3691e19dabbfbb4a
+size 22585

--- a/public/assets/moves/animations/withdraw.mp4
+++ b/public/assets/moves/animations/withdraw.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0c22a1053e9638128466131c6b837774060f7f33b0e75c9f20d814d2af74f1a
+size 26623

--- a/public/assets/moves/animations/wrap.mp4
+++ b/public/assets/moves/animations/wrap.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e05d5824e790c55822c0850c8115ca03d4c24ebddbb95dd2db5960d67ee2247
+size 20749

--- a/sql/move_animation.sql
+++ b/sql/move_animation.sql
@@ -12,172 +12,503 @@ CREATE TABLE IF NOT EXISTS move_animation
             move_animation_move_id_fk
             references
                 move,
-    path TEXT
+    path TEXT,
+    mimeType Text
 );
 
-INSERT INTO move_animation (move_id, path)
-VALUES ((SELECT id FROM move WHERE name = 'Absorb'),        '/assets/moves/animations/absorb.webm'),
-       ((SELECT id FROM move WHERE name = 'Acid'),          '/assets/moves/animations/acid.webm'),
-       ((SELECT id FROM move WHERE name = 'Acid Armor'),    '/assets/moves/animations/acidarmor.webm'),
-       ((SELECT id FROM move WHERE name = 'Agility'),       '/assets/moves/animations/agility.webm'),
-       ((SELECT id FROM move WHERE name = 'Amnesia'),       '/assets/moves/animations/amnesia.webm'),
-       ((SELECT id FROM move WHERE name = 'Aurora Beam'),   '/assets/moves/animations/aurorabeam.webm'),
-       ((SELECT id FROM move WHERE name = 'Barrage'),       '/assets/moves/animations/barrage.webm'),
-       ((SELECT id FROM move WHERE name = 'Barrier'),       '/assets/moves/animations/barrier.webm'),
-       ((SELECT id FROM move WHERE name = 'Bide'),          '/assets/moves/animations/bide.webm'),
-       ((SELECT id FROM move WHERE name = 'Bind'),          '/assets/moves/animations/bind.webm'),
-       ((SELECT id FROM move WHERE name = 'Bite'),          '/assets/moves/animations/bite.webm'),
-       ((SELECT id FROM move WHERE name = 'Blizzard'),      '/assets/moves/animations/blizzard.webm'),
-       ((SELECT id FROM move WHERE name = 'Body Slam'),     '/assets/moves/animations/bodyslam.webm'),
-       ((SELECT id FROM move WHERE name = 'Bone Club'),     '/assets/moves/animations/boneclub.webm'),
-       ((SELECT id FROM move WHERE name = 'Bonemerang'),    '/assets/moves/animations/bonemerang.webm'),
-       ((SELECT id FROM move WHERE name = 'Bubble'),        '/assets/moves/animations/bubble.webm'),
-       ((SELECT id FROM move WHERE name = 'Bubble Beam'),   '/assets/moves/animations/bubblebeam.webm'),
-       ((SELECT id FROM move WHERE name = 'Clamp'),         '/assets/moves/animations/clamp.webm'),
-       ((SELECT id FROM move WHERE name = 'Comet Punch'),   '/assets/moves/animations/cometpunch.webm'),
-       ((SELECT id FROM move WHERE name = 'Confuse Ray'),   '/assets/moves/animations/confuseray.webm'),
-       ((SELECT id FROM move WHERE name = 'Confusion'),     '/assets/moves/animations/confusion.webm'),
-       ((SELECT id FROM move WHERE name = 'Constrict'),     '/assets/moves/animations/constrict.webm'),
-       ((SELECT id FROM move WHERE name = 'Conversion'),    '/assets/moves/animations/conversion.webm'),
-       ((SELECT id FROM move WHERE name = 'Counter'),       '/assets/moves/animations/counter.webm'),
-       ((SELECT id FROM move WHERE name = 'Crabhammer'),    '/assets/moves/animations/crabhammer.webm'),
-       ((SELECT id FROM move WHERE name = 'Cut'),           '/assets/moves/animations/cut.webm'),
-       ((SELECT id FROM move WHERE name = 'Defense Curl'),  '/assets/moves/animations/defensecurl.webm'),
-       ((SELECT id FROM move WHERE name = 'Dig'),           '/assets/moves/animations/dig.webm'),
-       ((SELECT id FROM move WHERE name = 'Disable'),       '/assets/moves/animations/disable.webm'),
-       ((SELECT id FROM move WHERE name = 'Dizzy Punch'),   '/assets/moves/animations/dizzypunch.webm'),
-       ((SELECT id FROM move WHERE name = 'Double Kick'),   '/assets/moves/animations/doublekick.webm'),
-       ((SELECT id FROM move WHERE name = 'Double Slap'),   '/assets/moves/animations/doubleslap.webm'),
-       ((SELECT id FROM move WHERE name = 'Double Team'),   '/assets/moves/animations/doubleteam.webm'),
-       ((SELECT id FROM move WHERE name = 'Double-Edge'),   '/assets/moves/animations/doubleedge.webm'),
-       ((SELECT id FROM move WHERE name = 'Dragon Rage'),   '/assets/moves/animations/dragonrage.webm'),
-       ((SELECT id FROM move WHERE name = 'Dream Eater'),   '/assets/moves/animations/dreameater.webm'),
-       ((SELECT id FROM move WHERE name = 'Drill Peck'),    '/assets/moves/animations/drillpeck.webm'),
-       ((SELECT id FROM move WHERE name = 'Earthquake'),    '/assets/moves/animations/earthquake.webm'),
-       ((SELECT id FROM move WHERE name = 'Egg Bomb'),      '/assets/moves/animations/eggbomb.webm'),
-       ((SELECT id FROM move WHERE name = 'Ember'),         '/assets/moves/animations/ember.webm'),
-       ((SELECT id FROM move WHERE name = 'Explosion'),     '/assets/moves/animations/explosion.webm'),
-       ((SELECT id FROM move WHERE name = 'Fire Blast'),    '/assets/moves/animations/fireblast.webm'),
-       ((SELECT id FROM move WHERE name = 'Fire Punch'),    '/assets/moves/animations/firepunch.webm'),
-       ((SELECT id FROM move WHERE name = 'Fire Spin'),     '/assets/moves/animations/firespin.webm'),
-       ((SELECT id FROM move WHERE name = 'Fissure'),       '/assets/moves/animations/fissure.webm'),
-       ((SELECT id FROM move WHERE name = 'Flamethrower'),  '/assets/moves/animations/flamethrower.webm'),
-       ((SELECT id FROM move WHERE name = 'Flash'),         '/assets/moves/animations/flash.webm'),
-       ((SELECT id FROM move WHERE name = 'Fly'),           '/assets/moves/animations/fly.webm'),
-       ((SELECT id FROM move WHERE name = 'Focus Energy'),  '/assets/moves/animations/focusenergy.webm'),
-       ((SELECT id FROM move WHERE name = 'Fury Attack'),   '/assets/moves/animations/furyattack.webm'),
-       ((SELECT id FROM move WHERE name = 'Fury Swipes'),   '/assets/moves/animations/furyswipes.webm'),
-       ((SELECT id FROM move WHERE name = 'Glare'),         '/assets/moves/animations/glare.webm'),
-       ((SELECT id FROM move WHERE name = 'Growl'),         '/assets/moves/animations/growl.webm'),
-       ((SELECT id FROM move WHERE name = 'Growth'),        '/assets/moves/animations/growth.webm'),
-       ((SELECT id FROM move WHERE name = 'Guillotine'),    '/assets/moves/animations/guillotine.webm'),
-       ((SELECT id FROM move WHERE name = 'Gust'),          '/assets/moves/animations/gust.webm'),
-       ((SELECT id FROM move WHERE name = 'Harden'),        '/assets/moves/animations/harden.webm'),
-       ((SELECT id FROM move WHERE name = 'Haze'),          '/assets/moves/animations/haze.webm'),
-       ((SELECT id FROM move WHERE name = 'Headbutt'),      '/assets/moves/animations/headbutt.webm'),
-       ((SELECT id FROM move WHERE name = 'High Jump Kick'),'/assets/moves/animations/hijumpkick.webm'),
-       ((SELECT id FROM move WHERE name = 'Horn Attack'),   '/assets/moves/animations/hornattack.webm'),
-       ((SELECT id FROM move WHERE name = 'Horn Drill'),    '/assets/moves/animations/horndrill.webm'),
-       ((SELECT id FROM move WHERE name = 'Hydro Pump'),    '/assets/moves/animations/hydropump.webm'),
-       ((SELECT id FROM move WHERE name = 'Hyper Beam'),    '/assets/moves/animations/hyperbeam.webm'),
-       ((SELECT id FROM move WHERE name = 'Hyper Fang'),    '/assets/moves/animations/hyperfang.webm'),
-       ((SELECT id FROM move WHERE name = 'Hypnosis'),      '/assets/moves/animations/hypnosis.webm'),
-       ((SELECT id FROM move WHERE name = 'Ice Beam'),      '/assets/moves/animations/icebeam.webm'),
-       ((SELECT id FROM move WHERE name = 'Ice Punch'),     '/assets/moves/animations/icepunch.webm'),
-       ((SELECT id FROM move WHERE name = 'Jump Kick'),     '/assets/moves/animations/jumpkick.webm'),
-       ((SELECT id FROM move WHERE name = 'Karate Chop'),   '/assets/moves/animations/karatechop.webm'),
-       ((SELECT id FROM move WHERE name = 'Kinesis'),       '/assets/moves/animations/kinesis.webm'),
-       ((SELECT id FROM move WHERE name = 'Leech Life'),    '/assets/moves/animations/leechlife.webm'),
-       ((SELECT id FROM move WHERE name = 'Leech Seed'),    '/assets/moves/animations/leechseed.webm'),
-       ((SELECT id FROM move WHERE name = 'Leer'),          '/assets/moves/animations/leer.webm'),
-       ((SELECT id FROM move WHERE name = 'Lick'),          '/assets/moves/animations/lick.webm'),
-       ((SELECT id FROM move WHERE name = 'Light Screen'),  '/assets/moves/animations/lightscreen.webm'),
-       ((SELECT id FROM move WHERE name = 'Lovely Kiss'),   '/assets/moves/animations/lovelykiss.webm'),
-       ((SELECT id FROM move WHERE name = 'Low Kick'),      '/assets/moves/animations/lowkick.webm'),
-       ((SELECT id FROM move WHERE name = 'Meditate'),      '/assets/moves/animations/meditate.webm'),
-       ((SELECT id FROM move WHERE name = 'Mega Drain'),    '/assets/moves/animations/megadrain.webm'),
-       ((SELECT id FROM move WHERE name = 'Mega Kick'),     '/assets/moves/animations/megakick.webm'),
-       ((SELECT id FROM move WHERE name = 'Mega Punch'),    '/assets/moves/animations/megapunch.webm'),
-       ((SELECT id FROM move WHERE name = 'Metronome'),     '/assets/moves/animations/metronome.webm'),
-       ((SELECT id FROM move WHERE name = 'Mimic'),         '/assets/moves/animations/mimic.webm'),
-       ((SELECT id FROM move WHERE name = 'Minimize'),      '/assets/moves/animations/minimize.webm'),
-       ((SELECT id FROM move WHERE name = 'Mirror Move'),   '/assets/moves/animations/mirrormove.webm'),
-       ((SELECT id FROM move WHERE name = 'Mist'),          '/assets/moves/animations/mist.webm'),
-       ((SELECT id FROM move WHERE name = 'Night Shade'),   '/assets/moves/animations/nightshade.webm'),
-       ((SELECT id FROM move WHERE name = 'Pay Day'),       '/assets/moves/animations/payday.webm'),
-       ((SELECT id FROM move WHERE name = 'Peck'),          '/assets/moves/animations/peck.webm'),
-       ((SELECT id FROM move WHERE name = 'Petal Dance'),   '/assets/moves/animations/petaldance.webm'),
-       ((SELECT id FROM move WHERE name = 'Pin Missile'),   '/assets/moves/animations/pinmissile.webm'),
-       ((SELECT id FROM move WHERE name = 'Poison Gas'),    '/assets/moves/animations/poisongas.webm'),
-       ((SELECT id FROM move WHERE name = 'Poison Powder'), '/assets/moves/animations/poisonpowder.webm'),
-       ((SELECT id FROM move WHERE name = 'Poison Sting'),  '/assets/moves/animations/poisonsting.webm'),
-       ((SELECT id FROM move WHERE name = 'Pound'),         '/assets/moves/animations/pound.webm'),
-       ((SELECT id FROM move WHERE name = 'Psybeam'),       '/assets/moves/animations/psybeam.webm'),
-       ((SELECT id FROM move WHERE name = 'Psychic'),       '/assets/moves/animations/psychic.webm'),
-       ((SELECT id FROM move WHERE name = 'Psywave'),       '/assets/moves/animations/psywave.webm'),
-       ((SELECT id FROM move WHERE name = 'Quick Attack'),  '/assets/moves/animations/quickattack.webm'),
-       ((SELECT id FROM move WHERE name = 'Rage'),          '/assets/moves/animations/rage.webm'),
-       ((SELECT id FROM move WHERE name = 'Razor Leaf'),    '/assets/moves/animations/razorleaf.webm'),
-       ((SELECT id FROM move WHERE name = 'Razor Wind'),    '/assets/moves/animations/razorwind.webm'),
-       ((SELECT id FROM move WHERE name = 'Recover'),       '/assets/moves/animations/recover.webm'),
-       ((SELECT id FROM move WHERE name = 'Reflect'),       '/assets/moves/animations/reflect.webm'),
-       ((SELECT id FROM move WHERE name = 'Rest'),          '/assets/moves/animations/rest.webm'),
-       ((SELECT id FROM move WHERE name = 'Roar'),          '/assets/moves/animations/roar.webm'),
-       ((SELECT id FROM move WHERE name = 'Rock Slide'),    '/assets/moves/animations/rockslide.webm'),
-       ((SELECT id FROM move WHERE name = 'Rock Throw'),    '/assets/moves/animations/rockthrow.webm'),
-       ((SELECT id FROM move WHERE name = 'Rolling Kick'),  '/assets/moves/animations/rollingkick.webm'),
-       ((SELECT id FROM move WHERE name = 'Sand Attack'),   '/assets/moves/animations/sandattack.webm'),
-       ((SELECT id FROM move WHERE name = 'Scratch'),       '/assets/moves/animations/scratch.webm'),
-       ((SELECT id FROM move WHERE name = 'Screech'),       '/assets/moves/animations/screech.webm'),
-       ((SELECT id FROM move WHERE name = 'Seismic Toss'),  '/assets/moves/animations/seismictoss.webm'),
-       ((SELECT id FROM move WHERE name = 'Self-Destruct'), '/assets/moves/animations/selfdestruct.webm'),
-       ((SELECT id FROM move WHERE name = 'Sharpen'),       '/assets/moves/animations/sharpen.webm'),
-       ((SELECT id FROM move WHERE name = 'Sing'),          '/assets/moves/animations/sing.webm'),
-       ((SELECT id FROM move WHERE name = 'Skull Bash'),    '/assets/moves/animations/skullbash.webm'),
-       ((SELECT id FROM move WHERE name = 'Sky Attack'),    '/assets/moves/animations/skyattack.webm'),
-       ((SELECT id FROM move WHERE name = 'Slam'),          '/assets/moves/animations/slam.webm'),
-       ((SELECT id FROM move WHERE name = 'Slash'),         '/assets/moves/animations/slash.webm'),
-       ((SELECT id FROM move WHERE name = 'Sleep Powder'),  '/assets/moves/animations/sleeppowder.webm'),
-       ((SELECT id FROM move WHERE name = 'Sludge'),        '/assets/moves/animations/sludge.webm'),
-       ((SELECT id FROM move WHERE name = 'Smog'),          '/assets/moves/animations/smog.webm'),
-       ((SELECT id FROM move WHERE name = 'Smokescreen'),   '/assets/moves/animations/smokescreen.webm'),
-       ((SELECT id FROM move WHERE name = 'Soft-Boiled'),   '/assets/moves/animations/softboiled.webm'),
-       ((SELECT id FROM move WHERE name = 'Solar Beam'),    '/assets/moves/animations/solarbeam.webm'),
-       ((SELECT id FROM move WHERE name = 'Sonic Boom'),    '/assets/moves/animations/sonicboom.webm'),
-       ((SELECT id FROM move WHERE name = 'Spike Cannon'),  '/assets/moves/animations/spikecannon.webm'),
-       ((SELECT id FROM move WHERE name = 'Splash'),        '/assets/moves/animations/splash.webm'),
-       ((SELECT id FROM move WHERE name = 'Spore'),         '/assets/moves/animations/spore.webm'),
-       ((SELECT id FROM move WHERE name = 'Stomp'),         '/assets/moves/animations/stomp.webm'),
-       ((SELECT id FROM move WHERE name = 'Strength'),      '/assets/moves/animations/strength.webm'),
-       ((SELECT id FROM move WHERE name = 'String Shot'),   '/assets/moves/animations/stringshot.webm'),
-       ((SELECT id FROM move WHERE name = 'Struggle'),      '/assets/moves/animations/struggle.webm'),
-       ((SELECT id FROM move WHERE name = 'Stun Spore'),    '/assets/moves/animations/stunspore.webm'),
-       ((SELECT id FROM move WHERE name = 'Submission'),    '/assets/moves/animations/submission.webm'),
-       ((SELECT id FROM move WHERE name = 'Substitute'),    '/assets/moves/animations/substitute.webm'),
-       ((SELECT id FROM move WHERE name = 'Super Fang'),    '/assets/moves/animations/superfang.webm'),
-       ((SELECT id FROM move WHERE name = 'Supersonic'),    '/assets/moves/animations/supersonic.webm'),
-       ((SELECT id FROM move WHERE name = 'Surf'),          '/assets/moves/animations/surf.webm'),
-       ((SELECT id FROM move WHERE name = 'Swift'),         '/assets/moves/animations/swift.webm'),
-       ((SELECT id FROM move WHERE name = 'Swords Dance'),  '/assets/moves/animations/swordsdance.webm'),
-       ((SELECT id FROM move WHERE name = 'Tackle'),        '/assets/moves/animations/tackle.webm'),
-       ((SELECT id FROM move WHERE name = 'Tail Whip'),     '/assets/moves/animations/tailwhip.webm'),
-       ((SELECT id FROM move WHERE name = 'Take Down'),     '/assets/moves/animations/takedown.webm'),
-       ((SELECT id FROM move WHERE name = 'Teleport'),      '/assets/moves/animations/teleport.webm'),
-       ((SELECT id FROM move WHERE name = 'Thrash'),        '/assets/moves/animations/thrash.webm'),
-       ((SELECT id FROM move WHERE name = 'Thunder'),       '/assets/moves/animations/thunder.webm'),
-       ((SELECT id FROM move WHERE name = 'Thunder Punch'), '/assets/moves/animations/thunderpunch.webm'),
-       ((SELECT id FROM move WHERE name = 'Thunder Shock'), '/assets/moves/animations/thundershock.webm'),
-       ((SELECT id FROM move WHERE name = 'Thunder Wave'),  '/assets/moves/animations/thunderwave.webm'),
-       ((SELECT id FROM move WHERE name = 'Thunderbolt'),   '/assets/moves/animations/thunderbolt.webm'),
-       ((SELECT id FROM move WHERE name = 'Toxic'),         '/assets/moves/animations/toxic.webm'),
-       ((SELECT id FROM move WHERE name = 'Transform'),     '/assets/moves/animations/transform.webm'),
-       ((SELECT id FROM move WHERE name = 'Tri Attack'),    '/assets/moves/animations/triattack.webm'),
-       ((SELECT id FROM move WHERE name = 'Twineedle'),     '/assets/moves/animations/twineedle.webm'),
-       ((SELECT id FROM move WHERE name = 'Vice Grip'),     '/assets/moves/animations/vicegrip.webm'),
-       ((SELECT id FROM move WHERE name = 'Vine Whip'),     '/assets/moves/animations/vinewhip.webm'),
-       ((SELECT id FROM move WHERE name = 'Water Gun'),     '/assets/moves/animations/watergun.webm'),
-       ((SELECT id FROM move WHERE name = 'Waterfall'),     '/assets/moves/animations/waterfall.webm'),
-       ((SELECT id FROM move WHERE name = 'Whirlwind'),     '/assets/moves/animations/whirlwind.webm'),
-       ((SELECT id FROM move WHERE name = 'Wing Attack'),   '/assets/moves/animations/wingattack.webm'),
-       ((SELECT id FROM move WHERE name = 'Withdraw'),      '/assets/moves/animations/withdraw.webm'),
-       ((SELECT id FROM move WHERE name = 'Wrap'),          '/assets/moves/animations/wrap.webm');
+INSERT INTO move_animation (move_id, path, mimeType)
+VALUES
+    ((SELECT id FROM move WHERE name = 'Absorb'),        '/assets/moves/animations/absorb.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Absorb'),        '/assets/moves/animations/absorb.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Acid'),          '/assets/moves/animations/acid.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Acid'),          '/assets/moves/animations/acid.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Acid Armor'),    '/assets/moves/animations/acidarmor.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Acid Armor'),    '/assets/moves/animations/acidarmor.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Agility'),       '/assets/moves/animations/agility.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Agility'),       '/assets/moves/animations/agility.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Amnesia'),       '/assets/moves/animations/amnesia.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Amnesia'),       '/assets/moves/animations/amnesia.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Aurora Beam'),   '/assets/moves/animations/aurorabeam.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Aurora Beam'),   '/assets/moves/animations/aurorabeam.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Barrage'),       '/assets/moves/animations/barrage.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Barrage'),       '/assets/moves/animations/barrage.webm', 'video/webm'),
+
+    ((SELECT id FROM move WHERE name = 'Barrier'),       '/assets/moves/animations/barrier.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Barrier'),       '/assets/moves/animations/barrier.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Bide'),          '/assets/moves/animations/bide.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Bide'),          '/assets/moves/animations/bide.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Bind'),          '/assets/moves/animations/bind.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Bind'),          '/assets/moves/animations/bind.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Bite'),          '/assets/moves/animations/bite.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Bite'),          '/assets/moves/animations/bite.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Blizzard'),      '/assets/moves/animations/blizzard.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Blizzard'),      '/assets/moves/animations/blizzard.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Body Slam'),     '/assets/moves/animations/bodyslam.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Body Slam'),     '/assets/moves/animations/bodyslam.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Bone Club'),     '/assets/moves/animations/boneclub.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Bone Club'),     '/assets/moves/animations/boneclub.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Bonemerang'),    '/assets/moves/animations/bonemerang.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Bonemerang'),    '/assets/moves/animations/bonemerang.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Bubble'),        '/assets/moves/animations/bubble.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Bubble'),        '/assets/moves/animations/bubble.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Bubble Beam'),   '/assets/moves/animations/bubblebeam.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Bubble Beam'),   '/assets/moves/animations/bubblebeam.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Clamp'),         '/assets/moves/animations/clamp.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Clamp'),         '/assets/moves/animations/clamp.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Comet Punch'),   '/assets/moves/animations/cometpunch.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Comet Punch'),   '/assets/moves/animations/cometpunch.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Confuse Ray'),   '/assets/moves/animations/confuseray.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Confuse Ray'),   '/assets/moves/animations/confuseray.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Confusion'),     '/assets/moves/animations/confusion.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Confusion'),     '/assets/moves/animations/confusion.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Constrict'),     '/assets/moves/animations/constrict.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Constrict'),     '/assets/moves/animations/constrict.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Conversion'),    '/assets/moves/animations/conversion.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Conversion'),    '/assets/moves/animations/conversion.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Counter'),       '/assets/moves/animations/counter.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Counter'),       '/assets/moves/animations/counter.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Crabhammer'),    '/assets/moves/animations/crabhammer.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Crabhammer'),    '/assets/moves/animations/crabhammer.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Cut'),           '/assets/moves/animations/cut.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Cut'),           '/assets/moves/animations/cut.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Defense Curl'),  '/assets/moves/animations/defensecurl.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Defense Curl'),  '/assets/moves/animations/defensecurl.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Dig'),           '/assets/moves/animations/dig.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Dig'),           '/assets/moves/animations/dig.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Disable'),       '/assets/moves/animations/disable.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Disable'),       '/assets/moves/animations/disable.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Dizzy Punch'),   '/assets/moves/animations/dizzypunch.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Dizzy Punch'),   '/assets/moves/animations/dizzypunch.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Double Kick'),   '/assets/moves/animations/doublekick.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Double Kick'),   '/assets/moves/animations/doublekick.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Double Slap'),   '/assets/moves/animations/doubleslap.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Double Slap'),   '/assets/moves/animations/doubleslap.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Double Team'),   '/assets/moves/animations/doubleteam.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Double Team'),   '/assets/moves/animations/doubleteam.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Double-Edge'),   '/assets/moves/animations/doubleedge.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Double-Edge'),   '/assets/moves/animations/doubleedge.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Dragon Rage'),   '/assets/moves/animations/dragonrage.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Dragon Rage'),   '/assets/moves/animations/dragonrage.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Dream Eater'),   '/assets/moves/animations/dreameater.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Dream Eater'),   '/assets/moves/animations/dreameater.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Drill Peck'),    '/assets/moves/animations/drillpeck.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Drill Peck'),    '/assets/moves/animations/drillpeck.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Earthquake'),    '/assets/moves/animations/earthquake.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Earthquake'),    '/assets/moves/animations/earthquake.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Egg Bomb'),      '/assets/moves/animations/eggbomb.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Egg Bomb'),      '/assets/moves/animations/eggbomb.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Ember'),         '/assets/moves/animations/ember.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Ember'),         '/assets/moves/animations/ember.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Explosion'),     '/assets/moves/animations/explosion.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Explosion'),     '/assets/moves/animations/explosion.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Fire Blast'),    '/assets/moves/animations/fireblast.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Fire Blast'),    '/assets/moves/animations/fireblast.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Fire Punch'),    '/assets/moves/animations/firepunch.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Fire Punch'),    '/assets/moves/animations/firepunch.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Fire Spin'),     '/assets/moves/animations/firespin.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Fire Spin'),     '/assets/moves/animations/firespin.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Fissure'),       '/assets/moves/animations/fissure.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Fissure'),       '/assets/moves/animations/fissure.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Flamethrower'),  '/assets/moves/animations/flamethrower.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Flamethrower'),  '/assets/moves/animations/flamethrower.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Flash'),         '/assets/moves/animations/flash.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Flash'),         '/assets/moves/animations/flash.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Fly'),           '/assets/moves/animations/fly.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Fly'),           '/assets/moves/animations/fly.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Focus Energy'),  '/assets/moves/animations/focusenergy.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Focus Energy'),  '/assets/moves/animations/focusenergy.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Fury Attack'),   '/assets/moves/animations/furyattack.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Fury Attack'),   '/assets/moves/animations/furyattack.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Fury Swipes'),   '/assets/moves/animations/furyswipes.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Fury Swipes'),   '/assets/moves/animations/furyswipes.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Glare'),         '/assets/moves/animations/glare.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Glare'),         '/assets/moves/animations/glare.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Growl'),         '/assets/moves/animations/growl.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Growl'),         '/assets/moves/animations/growl.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Growth'),        '/assets/moves/animations/growth.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Growth'),        '/assets/moves/animations/growth.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Guillotine'),    '/assets/moves/animations/guillotine.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Guillotine'),    '/assets/moves/animations/guillotine.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Gust'),          '/assets/moves/animations/gust.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Gust'),          '/assets/moves/animations/gust.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Harden'),        '/assets/moves/animations/harden.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Harden'),        '/assets/moves/animations/harden.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Haze'),          '/assets/moves/animations/haze.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Haze'),          '/assets/moves/animations/haze.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Headbutt'),      '/assets/moves/animations/headbutt.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Headbutt'),      '/assets/moves/animations/headbutt.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'High Jump Kick'),'/assets/moves/animations/hijumpkick.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'High Jump Kick'),'/assets/moves/animations/hijumpkick.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Horn Attack'),   '/assets/moves/animations/hornattack.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Horn Attack'),   '/assets/moves/animations/hornattack.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Horn Drill'),    '/assets/moves/animations/horndrill.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Horn Drill'),    '/assets/moves/animations/horndrill.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Hydro Pump'),    '/assets/moves/animations/hydropump.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Hydro Pump'),    '/assets/moves/animations/hydropump.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Hyper Beam'),    '/assets/moves/animations/hyperbeam.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Hyper Beam'),    '/assets/moves/animations/hyperbeam.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Hyper Fang'),    '/assets/moves/animations/hyperfang.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Hyper Fang'),    '/assets/moves/animations/hyperfang.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Hypnosis'),      '/assets/moves/animations/hypnosis.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Hypnosis'),      '/assets/moves/animations/hypnosis.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Ice Beam'),      '/assets/moves/animations/icebeam.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Ice Beam'),      '/assets/moves/animations/icebeam.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Ice Punch'),     '/assets/moves/animations/icepunch.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Ice Punch'),     '/assets/moves/animations/icepunch.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Jump Kick'),     '/assets/moves/animations/jumpkick.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Jump Kick'),     '/assets/moves/animations/jumpkick.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Karate Chop'),   '/assets/moves/animations/karatechop.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Karate Chop'),   '/assets/moves/animations/karatechop.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Kinesis'),       '/assets/moves/animations/kinesis.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Kinesis'),       '/assets/moves/animations/kinesis.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Leech Life'),    '/assets/moves/animations/leechlife.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Leech Life'),    '/assets/moves/animations/leechlife.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Leech Seed'),    '/assets/moves/animations/leechseed.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Leech Seed'),    '/assets/moves/animations/leechseed.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Leer'),          '/assets/moves/animations/leer.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Leer'),          '/assets/moves/animations/leer.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Lick'),          '/assets/moves/animations/lick.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Lick'),          '/assets/moves/animations/lick.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Light Screen'),  '/assets/moves/animations/lightscreen.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Light Screen'),  '/assets/moves/animations/lightscreen.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Lovely Kiss'),   '/assets/moves/animations/lovelykiss.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Lovely Kiss'),   '/assets/moves/animations/lovelykiss.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Low Kick'),      '/assets/moves/animations/lowkick.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Low Kick'),      '/assets/moves/animations/lowkick.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Meditate'),      '/assets/moves/animations/meditate.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Meditate'),      '/assets/moves/animations/meditate.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Mega Drain'),    '/assets/moves/animations/megadrain.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Mega Drain'),    '/assets/moves/animations/megadrain.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Mega Kick'),     '/assets/moves/animations/megakick.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Mega Kick'),     '/assets/moves/animations/megakick.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Mega Punch'),    '/assets/moves/animations/megapunch.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Mega Punch'),    '/assets/moves/animations/megapunch.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Metronome'),     '/assets/moves/animations/metronome.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Metronome'),     '/assets/moves/animations/metronome.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Mimic'),         '/assets/moves/animations/mimic.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Mimic'),         '/assets/moves/animations/mimic.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Minimize'),      '/assets/moves/animations/minimize.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Minimize'),      '/assets/moves/animations/minimize.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Mirror Move'),   '/assets/moves/animations/mirrormove.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Mirror Move'),   '/assets/moves/animations/mirrormove.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Mist'),          '/assets/moves/animations/mist.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Mist'),          '/assets/moves/animations/mist.mp4', 'video/mp4'),
+    
+    ((SELECT id FROM move WHERE name = 'Night Shade'),   '/assets/moves/animations/nightshade.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Night Shade'),   '/assets/moves/animations/nightshade.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Pay Day'),       '/assets/moves/animations/payday.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Pay Day'),       '/assets/moves/animations/payday.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Peck'),          '/assets/moves/animations/peck.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Peck'),          '/assets/moves/animations/peck.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Petal Dance'),   '/assets/moves/animations/petaldance.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Petal Dance'),   '/assets/moves/animations/petaldance.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Pin Missile'),   '/assets/moves/animations/pinmissile.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Pin Missile'),   '/assets/moves/animations/pinmissile.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Poison Gas'),    '/assets/moves/animations/poisongas.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Poison Gas'),    '/assets/moves/animations/poisongas.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Poison Powder'), '/assets/moves/animations/poisonpowder.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Poison Powder'), '/assets/moves/animations/poisonpowder.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Poison Sting'),  '/assets/moves/animations/poisonsting.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Poison Sting'),  '/assets/moves/animations/poisonsting.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Pound'),         '/assets/moves/animations/pound.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Pound'),         '/assets/moves/animations/pound.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Psybeam'),       '/assets/moves/animations/psybeam.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Psybeam'),       '/assets/moves/animations/psybeam.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Psychic'),       '/assets/moves/animations/psychic.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Psychic'),       '/assets/moves/animations/psychic.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Psywave'),       '/assets/moves/animations/psywave.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Psywave'),       '/assets/moves/animations/psywave.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Quick Attack'),  '/assets/moves/animations/quickattack.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Quick Attack'),  '/assets/moves/animations/quickattack.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Rage'),          '/assets/moves/animations/rage.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Rage'),          '/assets/moves/animations/rage.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Razor Leaf'),    '/assets/moves/animations/razorleaf.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Razor Leaf'),    '/assets/moves/animations/razorleaf.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Razor Wind'),    '/assets/moves/animations/razorwind.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Razor Wind'),    '/assets/moves/animations/razorwind.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Recover'),       '/assets/moves/animations/recover.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Recover'),       '/assets/moves/animations/recover.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Reflect'),       '/assets/moves/animations/reflect.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Reflect'),       '/assets/moves/animations/reflect.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Rest'),          '/assets/moves/animations/rest.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Rest'),          '/assets/moves/animations/rest.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Roar'),          '/assets/moves/animations/roar.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Roar'),          '/assets/moves/animations/roar.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Rock Slide'),    '/assets/moves/animations/rockslide.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Rock Slide'),    '/assets/moves/animations/rockslide.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Rock Throw'),    '/assets/moves/animations/rockthrow.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Rock Throw'),    '/assets/moves/animations/rockthrow.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Rolling Kick'),  '/assets/moves/animations/rollingkick.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Rolling Kick'),  '/assets/moves/animations/rollingkick.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Sand Attack'),   '/assets/moves/animations/sandattack.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Sand Attack'),   '/assets/moves/animations/sandattack.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Scratch'),       '/assets/moves/animations/scratch.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Scratch'),       '/assets/moves/animations/scratch.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Screech'),       '/assets/moves/animations/screech.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Screech'),       '/assets/moves/animations/screech.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Seismic Toss'),  '/assets/moves/animations/seismictoss.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Seismic Toss'),  '/assets/moves/animations/seismictoss.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Self-Destruct'), '/assets/moves/animations/selfdestruct.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Self-Destruct'), '/assets/moves/animations/selfdestruct.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Sharpen'),       '/assets/moves/animations/sharpen.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Sharpen'),       '/assets/moves/animations/sharpen.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Sing'),          '/assets/moves/animations/sing.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Sing'),          '/assets/moves/animations/sing.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Skull Bash'),    '/assets/moves/animations/skullbash.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Skull Bash'),    '/assets/moves/animations/skullbash.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Sky Attack'),    '/assets/moves/animations/skyattack.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Sky Attack'),    '/assets/moves/animations/skyattack.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Slam'),          '/assets/moves/animations/slam.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Slam'),          '/assets/moves/animations/slam.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Slash'),         '/assets/moves/animations/slash.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Slash'),         '/assets/moves/animations/slash.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Sleep Powder'),  '/assets/moves/animations/sleeppowder.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Sleep Powder'),  '/assets/moves/animations/sleeppowder.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Sludge'),        '/assets/moves/animations/sludge.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Sludge'),        '/assets/moves/animations/sludge.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Smog'),          '/assets/moves/animations/smog.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Smog'),          '/assets/moves/animations/smog.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Smokescreen'),   '/assets/moves/animations/smokescreen.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Smokescreen'),   '/assets/moves/animations/smokescreen.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Soft-Boiled'),   '/assets/moves/animations/softboiled.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Soft-Boiled'),   '/assets/moves/animations/softboiled.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Solar Beam'),    '/assets/moves/animations/solarbeam.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Solar Beam'),    '/assets/moves/animations/solarbeam.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Sonic Boom'),    '/assets/moves/animations/sonicboom.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Sonic Boom'),    '/assets/moves/animations/sonicboom.mp4', 'video/webm'),
+
+    ((SELECT id FROM move WHERE name = 'Spike Cannon'),  '/assets/moves/animations/spikecannon.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Spike Cannon'),  '/assets/moves/animations/spikecannon.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Splash'),        '/assets/moves/animations/splash.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Splash'),        '/assets/moves/animations/splash.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Spore'),         '/assets/moves/animations/spore.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Spore'),         '/assets/moves/animations/spore.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Stomp'),         '/assets/moves/animations/stomp.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Stomp'),         '/assets/moves/animations/stomp.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Strength'),      '/assets/moves/animations/strength.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Strength'),      '/assets/moves/animations/strength.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'String Shot'),   '/assets/moves/animations/stringshot.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'String Shot'),   '/assets/moves/animations/stringshot.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Struggle'),      '/assets/moves/animations/struggle.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Struggle'),      '/assets/moves/animations/struggle.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Stun Spore'),    '/assets/moves/animations/stunspore.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Stun Spore'),    '/assets/moves/animations/stunspore.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Submission'),    '/assets/moves/animations/submission.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Submission'),    '/assets/moves/animations/submission.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Substitute'),    '/assets/moves/animations/substitute.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Substitute'),    '/assets/moves/animations/substitute.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Super Fang'),    '/assets/moves/animations/superfang.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Super Fang'),    '/assets/moves/animations/superfang.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Supersonic'),    '/assets/moves/animations/supersonic.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Supersonic'),    '/assets/moves/animations/supersonic.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Surf'),          '/assets/moves/animations/surf.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Surf'),          '/assets/moves/animations/surf.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Swift'),         '/assets/moves/animations/swift.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Swift'),         '/assets/moves/animations/swift.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Swords Dance'),  '/assets/moves/animations/swordsdance.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Swords Dance'),  '/assets/moves/animations/swordsdance.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Tackle'),        '/assets/moves/animations/tackle.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Tackle'),        '/assets/moves/animations/tackle.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Tail Whip'),     '/assets/moves/animations/tailwhip.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Tail Whip'),     '/assets/moves/animations/tailwhip.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Take Down'),     '/assets/moves/animations/takedown.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Take Down'),     '/assets/moves/animations/takedown.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Teleport'),      '/assets/moves/animations/teleport.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Teleport'),      '/assets/moves/animations/teleport.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Thrash'),        '/assets/moves/animations/thrash.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Thrash'),        '/assets/moves/animations/thrash.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Thunder'),       '/assets/moves/animations/thunder.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Thunder'),       '/assets/moves/animations/thunder.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Thunder Punch'), '/assets/moves/animations/thunderpunch.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Thunder Punch'), '/assets/moves/animations/thunderpunch.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Thunder Shock'), '/assets/moves/animations/thundershock.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Thunder Shock'), '/assets/moves/animations/thundershock.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Thunder Wave'),  '/assets/moves/animations/thunderwave.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Thunder Wave'),  '/assets/moves/animations/thunderwave.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Thunderbolt'),   '/assets/moves/animations/thunderbolt.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Thunderbolt'),   '/assets/moves/animations/thunderbolt.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Toxic'),         '/assets/moves/animations/toxic.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Toxic'),         '/assets/moves/animations/toxic.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Transform'),     '/assets/moves/animations/transform.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Transform'),     '/assets/moves/animations/transform.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Tri Attack'),    '/assets/moves/animations/triattack.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Tri Attack'),    '/assets/moves/animations/triattack.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Twineedle'),     '/assets/moves/animations/twineedle.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Twineedle'),     '/assets/moves/animations/twineedle.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Vice Grip'),     '/assets/moves/animations/vicegrip.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Vice Grip'),     '/assets/moves/animations/vicegrip.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Vine Whip'),     '/assets/moves/animations/vinewhip.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Vine Whip'),     '/assets/moves/animations/vinewhip.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Water Gun'),     '/assets/moves/animations/watergun.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Water Gun'),     '/assets/moves/animations/watergun.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Waterfall'),     '/assets/moves/animations/waterfall.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Waterfall'),     '/assets/moves/animations/waterfall.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Whirlwind'),     '/assets/moves/animations/whirlwind.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Whirlwind'),     '/assets/moves/animations/whirlwind.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Wing Attack'),   '/assets/moves/animations/wingattack.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Wing Attack'),   '/assets/moves/animations/wingattack.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Withdraw'),      '/assets/moves/animations/withdraw.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Withdraw'),      '/assets/moves/animations/withdraw.mp4', 'video/mp4'),
+
+    ((SELECT id FROM move WHERE name = 'Wrap'),          '/assets/moves/animations/wrap.webm', 'video/webm'),
+    ((SELECT id FROM move WHERE name = 'Wrap'),          '/assets/moves/animations/wrap.mp4', 'video/mp4');

--- a/src/Model/Animation.php
+++ b/src/Model/Animation.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace zbtnot\MonsterDb\Model;
+
+class Animation implements \JsonSerializable
+{
+    private string $path;
+    private string $mimeType;
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function setPath(string $path): self
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function getMimeType(): string
+    {
+        return $this->mimeType;
+    }
+
+    public function setMimeType(string $mimeType): self
+    {
+        $this->mimeType = $mimeType;
+
+        return $this;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'path' => $this->getPath(),
+            'mimeType' => $this->getMimeType(),
+        ];
+    }
+}

--- a/src/Model/DetailedMove.php
+++ b/src/Model/DetailedMove.php
@@ -4,30 +4,33 @@ namespace zbtnot\MonsterDb\Model;
 
 class DetailedMove implements \JsonSerializable
 {
-    private string $animationPath;
+    /** @var Animation[] */
+    private array $animations;
 
     /** @var GraphicMonster[] */
     private array $monsters;
 
-    public function __construct(private Move $move)
+    public function __construct(private readonly Move $move)
     {
+    }
+
+    /** @return Animation[] */
+    public function getAnimations(): array
+    {
+        return $this->animations;
+    }
+
+    /** @param Animation[] $animations */
+    public function setAnimations(array $animations): self
+    {
+        $this->animations = $animations;
+
+        return $this;
     }
 
     public function getMove(): Move
     {
         return $this->move;
-    }
-
-    public function getAnimationPath(): string
-    {
-        return $this->animationPath;
-    }
-
-    public function setAnimationPath(string $animationPath): self
-    {
-        $this->animationPath = $animationPath;
-
-        return $this;
     }
 
     /** @return GraphicMonster[] */
@@ -47,7 +50,7 @@ class DetailedMove implements \JsonSerializable
     public function jsonSerialize(): array
     {
         $fields = [
-            'animationPath' => $this->getAnimationPath(),
+            'animations' => $this->getAnimations(),
             'monsters' => $this->getMonsters(),
         ];
 

--- a/src/Repository/GraphicRepository.php
+++ b/src/Repository/GraphicRepository.php
@@ -2,6 +2,8 @@
 
 namespace zbtnot\MonsterDb\Repository;
 
+use zbtnot\MonsterDb\Model\Animation;
+
 class GraphicRepository extends Repository
 {
     /** @return array<int, string> */
@@ -73,18 +75,25 @@ class GraphicRepository extends Repository
         return $statement->fetchColumn();
     }
 
-    public function fetchAnimationByMoveId(int $moveId): string
+    /** @return Animation[] */
+    public function fetchAnimationsByMoveId(int $moveId): array
     {
         $sql = <<<SQL
             SELECT
-                path
+                path,
+                mimeType
             FROM move_animation
             WHERE move_id = :id
         SQL;
 
         $statement = $this->pdo->prepare($sql);
         $statement->execute([':id' => $moveId]);
+        $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);
 
-        return $statement->fetchColumn();
+        $animationMapper = fn(array $row) => (new Animation())
+            ->setPath($row['path'])
+            ->setMimeType($row['mimeType']);
+
+        return array_map($animationMapper, $rows);
     }
 }

--- a/src/Service/MoveService.php
+++ b/src/Service/MoveService.php
@@ -31,13 +31,13 @@ class MoveService
 
     public function fetchDetailedMoveByMove(Move $move): DetailedMove
     {
-        $animationPath = $this->graphicRepository->fetchAnimationByMoveId($move->getId());
+        $animations = $this->graphicRepository->fetchAnimationsByMoveId($move->getId());
         $monsterIds = $this->moveRepository->fetchMonsterIdsByMoveId($move->getId());
         $monsters = $this->monsterRepository->fetchMonstersByIds($monsterIds);
         $graphicMonsters = $this->graphicService->fetchGraphicMonstersFromMonsters($monsters);
 
         return (new DetailedMove($move))
-            ->setAnimationPath($animationPath)
+            ->setAnimations($animations)
             ->setMonsters($graphicMonsters);
     }
 }

--- a/test/Service/MoveServiceTest.php
+++ b/test/Service/MoveServiceTest.php
@@ -4,6 +4,7 @@ namespace zbtnot\MonsterDb\Tests\Service;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use zbtnot\MonsterDb\Model\Animation;
 use zbtnot\MonsterDb\Model\DetailedMove;
 use zbtnot\MonsterDb\Model\GraphicMonster;
 use zbtnot\MonsterDb\Model\Monster;
@@ -62,14 +63,16 @@ class MoveServiceTest extends TestCase
     {
 
         $move = (new Move())->setId(123);
-        $animationPath = '/foo.webm';
+        $animations = [
+            (new Animation())->setPath('/foo.webm')->setMimeType('video/webm')
+        ];
         $monster = (new Monster())->setId(456);
         $graphicMonster = new GraphicMonster($monster);
 
         $this->graphicRepository
-            ->method('fetchAnimationByMoveId')
+            ->method('fetchAnimationsByMoveId')
             ->with(123)
-            ->willReturn($animationPath);
+            ->willReturn($animations);
 
         $this->moveRepository
             ->method('fetchMonsterIdsByMoveId')
@@ -86,7 +89,7 @@ class MoveServiceTest extends TestCase
             ->with([$monster])
             ->willReturn([$graphicMonster]);
 
-        $expected = (new DetailedMove($move))->setAnimationPath($animationPath)->setMonsters([$graphicMonster]);
+        $expected = (new DetailedMove($move))->setAnimations($animations)->setMonsters([$graphicMonster]);
         $result = $this->moveService->fetchDetailedMoveByMove($move);
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
- Expands moves to support multiple animations
- Adds mp4 versions so iOS can fall-back to those
- Adds `playsinline` so iOS doesn't fullscreen the animation on move page load