### PR TITLE
Add monster locations

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -30,6 +30,8 @@ module.exports = {
     "rules": {
         indent: ['error', 4],
         'max-len': ['error', 120],
-        'operator-linebreak': ['error','after'],
+        'operator-linebreak': ['error', 'after'],
+        'no-plusplus': ['error', {'allowForLoopAfterthoughts': true}],
+        'object-curly-newline': ['error', {ObjectPattern: {multiline: true}}]
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ db:
 	sqlite3 db.sqlite < sql/sprite.sql
 	sqlite3 db.sqlite < sql/cry.sql
 	sqlite3 db.sqlite < sql/stat.sql
+	sqlite3 db.sqlite < sql/location.sql
+	sqlite3 db.sqlite < sql/monster_location.sql
 
 npm:
 	npm ci

--- a/js/LocationMap.js
+++ b/js/LocationMap.js
@@ -1,0 +1,48 @@
+export default class LocationMap {
+    constructor(locations) {
+        this.locations = locations;
+    }
+
+    /**
+     * @param locations Array<{height: int, width: int, x: int, y: int}>
+     * @returns {LocationMap}
+     */
+    static fromLocations(locations) {
+        const generatedLocations = LocationMap.generateLocations(locations);
+
+        return new LocationMap(generatedLocations);
+    }
+
+    /**
+     * Expands locations to include all possible coordinates from the location's width and height
+     * @param locations Array<{height: int, width: int, x: int, y: int}>
+     * @return {{}}
+     */
+    static generateLocations(locations) {
+        const generatedLocations = {};
+        locations.forEach((location) => {
+            for (let x = 0; x < location.width; x++) {
+                for (let y = 0; y < location.height; y++) {
+                    if (generatedLocations[location.x + x] === undefined) {
+                        generatedLocations[location.x + x] = {};
+                    }
+
+                    generatedLocations[location.x + x][location.y + y] = location;
+                }
+            }
+        });
+
+        return generatedLocations;
+    }
+
+    find(x, y) {
+        if (
+            this.locations[x] === undefined ||
+            this.locations[x][y] === undefined
+        ) {
+            return undefined;
+        }
+
+        return this.locations[x][y];
+    }
+}

--- a/js/components/monster/LocationCard.vue
+++ b/js/components/monster/LocationCard.vue
@@ -1,0 +1,124 @@
+<template>
+    <div class="rounded bg-slate-600 p-2">
+        <div class="text-2xl">Locations</div>
+        <span v-if="locations.length === 0">
+            There are no known locations for this monster.
+        </span>
+        <div v-else class="relative" @mousemove="coordinator">
+            <img
+                alt="an image of the map"
+                class="w-full h-auto"
+                src="/assets/map.png"
+                ref="map"
+            />
+            <span
+                class="absolute text-xl left-0 top-0 inline-block w-full bg-white text-black pl-2 opacity-80"
+            >
+                {{ selectedLocation }}
+            </span>
+            <div
+                class="absolute bg-red-500 opacity-80 animate-pulse"
+                v-for="(location, id) in locations"
+                :key="id"
+                :style="getMonsterLocationStyleString(location)"
+            ></div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+img {
+    image-rendering: pixelated;
+}
+</style>
+
+<script setup>
+import { onMounted, onUnmounted, ref } from 'vue';
+import LocationMap from '../../LocationMap';
+import axiosClient from '../../axios';
+
+defineProps({
+    locations: {
+        type: Array,
+        required: true,
+    },
+});
+
+const selectedLocation = ref('');
+const map = ref(null);
+const coordinateScale = ref({ x: 1, y: 1 });
+let locationMap = new LocationMap({});
+
+/**
+ * @param {HTMLImageElement} image
+ * @return {{width: number, height: number}}
+ */
+const calculatePixelScale = (image) => {
+    const { width, height, naturalWidth, naturalHeight } = image;
+
+    return {
+        width: width / naturalWidth,
+        height: height / naturalHeight,
+    };
+};
+
+/**
+ * @param {{x: number, y: number, width: number, height: number}} location
+ * @return {String}
+ */
+const getMonsterLocationStyleString = (location) => `
+    left: ${location.x * coordinateScale.value.x}px;
+    top: ${location.y * coordinateScale.value.y}px;
+    width: ${location.width * coordinateScale.value.x}px;
+    height: ${location.height * coordinateScale.value.y}px;
+`;
+
+const mapObserver = new ResizeObserver(() => {
+    if (!map.value) {
+        return;
+    }
+
+    const { width, height } = calculatePixelScale(map.value);
+    coordinateScale.value.x = width;
+    coordinateScale.value.y = height;
+});
+onMounted(async () => {
+    const locations = (await axiosClient.get('/location')).data;
+    locationMap = LocationMap.fromLocations(locations);
+
+    if (map.value) {
+        mapObserver.observe(map.value);
+    }
+});
+
+onUnmounted(() => {
+    mapObserver.disconnect();
+});
+
+/**
+ * Handles if the user hovers over a point on the map
+ * @param {MouseEvent} event
+ */
+const coordinator = (event) => {
+    const { clientX, clientY } = event;
+    const { left, top } = map.value.getBoundingClientRect();
+
+    // the position of the mouse relative to the map image
+    const x = clientX - left;
+    const y = clientY - top;
+
+    // the position of the mouse relative to the native resolution of the image
+    const pixelScale = calculatePixelScale(map.value);
+    const normalizedPoint = {
+        x: Math.floor(x / pixelScale.width),
+        y: Math.floor(y / pixelScale.height),
+    };
+
+    const location = locationMap.find(normalizedPoint.x, normalizedPoint.y);
+    if (location) {
+        selectedLocation.value = location.name;
+    } else {
+        selectedLocation.value = '';
+    }
+};
+</script>

--- a/js/components/pages/MonsterDetailsPage.vue
+++ b/js/components/pages/MonsterDetailsPage.vue
@@ -15,6 +15,7 @@
             </div>
             <div class="w-full md:w-2/3">
                 <MoveListCard :moves="monster.moves" class="mb-5" />
+                <LocationCard :locations="monster.locations" class="mb-5" />
             </div>
         </div>
     </template>
@@ -30,6 +31,7 @@ import MoveListCard from '../monster/MoveListCard.vue';
 import EvolutionCard from '../monster/EvolutionCard.vue';
 import SpriteCard from '../monster/SpriteCard.vue';
 import CryCard from '../monster/CryCard.vue';
+import LocationCard from '../monster/LocationCard.vue';
 
 const route = useRoute();
 const loaded = ref(false);
@@ -45,7 +47,9 @@ onMounted(async () => {
         error.value = 'There was a problem loading the page. Please try again.';
     } finally {
         loaded.value = true;
-        document.title = `${import.meta.env.VITE_APP_TITLE} | ${monster.value.name}`;
+        document.title = `${import.meta.env.VITE_APP_TITLE} | ${
+            monster.value.name
+        }`;
     }
 });
 </script>

--- a/public/assets/map.png
+++ b/public/assets/map.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78cce796d4d9097188a9958e9a80965209f4870e9c6762d02f823ab9a885c900
+size 2417

--- a/sql/location.sql
+++ b/sql/location.sql
@@ -1,0 +1,61 @@
+-- location table
+CREATE TABLE IF NOT EXISTS location
+(
+    id      INTEGER
+            CONSTRAINT location_pk PRIMARY KEY AUTOINCREMENT,
+    name    TEXT,
+    x       INTEGER, -- the top-left x-coordinate of the location
+    y       INTEGER, -- the top-left y-coordinate of the location
+    width   INTEGER, -- the width in pixels of the location on the map
+    height  INTEGER -- the height in pixels of the location on the map
+);
+
+INSERT INTO location (name, x, y, width, height)
+VALUES
+    ('Route 1',                     32,     72,     8,  16),
+    ('Route 2',                     32,     40,     8,  24),
+    ('Route 3',                     40,     24,     24, 8),
+    ('Route 4',                     56,     16,     40, 8),
+    ('Route 5',                     96,     24,     8,  16),
+    ('Route 6',                     96,     48,     8,  24),
+    ('Route 7',                     80,     40,     16, 8),
+    ('Route 8',                     104,    40,     24, 8),
+    ('Route 9',                     104,    16,     32, 8),
+    ('Route 10',                    128,    32,     8,  8),
+    ('Route 11',                    104,    72,     24, 8),
+    ('Route 12',                    128,    48,     8,  40),
+    ('Route 13',                    104,    88,     32, 8),
+    ('Route 14',                    104,    96,     8,  16),
+    ('Route 15',                    88,     104,    16, 8),
+    ('Route 16',                    48,     40,     24, 8),
+    ('Route 17',                    48,     48,     8,  56),
+    ('Route 18',                    48,     104,    32, 8),
+    ('Route 19',                    80,     112,    8,  16),
+    ('Route 20',                    40,     120,    40, 8),
+    ('Route 21',                    32,     96,     8,  24),
+    ('Route 22',                    16,     64,     16, 8),
+    ('Route 23',                    16,     24,     8,  40),
+    ('Route 24',                    96,     8,      8,  8),
+    ('Route 25',                    96,     0,      24, 8),
+    ('Pallet Town',                 32,     88,     8,  8),
+    ('Viridian City',               32,     64,     8,  8),
+    ('Pewter City',                 32,     24,     8,  8),
+    ('Cerulean City',               96,     16,     8,  8),
+    ('Cerulean Cave',               96,     16,     4,  4),
+    ('Saffron City',                96,     40,     8,  8),
+    ('Vermilion City',              96,     72,     8,  8),
+    ('Celadon City',                72,     40,     8,  8),
+    ('Lavender Town',               128,    40,     8,  8),
+    ('Power Plant',                 136,    32,     8,  8),
+    ('Fuschia City',                80,     104,    8,  8),
+    ('Safari Zone',                 80,     104,    4,  4),
+    ('Cinnabar Island',             32,     120,    8,  8),
+    ('Viridian Forest',             32,     32,     8,  8),
+    ('Diglett''s Cave',             40,     32,     8,  8),
+    ('Mt. Moon',                    64,     16,     8,  8),
+    ('Underground Path (North)',    96,     32,     8,  8),
+    ('Underground Path (South)',    96,     48,     8,  8),
+    ('Rock Tunnel',                 128,    24,     8,  8),
+    ('Indigo Plateau',              16,     16,     8,  8),
+    ('Victory Road',                16,     32,     8,  8),
+    ('Seafoam Islands',             56,     120,    8,  8);

--- a/sql/monster_location.sql
+++ b/sql/monster_location.sql
@@ -1,0 +1,116 @@
+-- monster_location table
+CREATE TABLE IF NOT EXISTS monster_location (
+    id INTEGER
+        CONSTRAINT monster_location_pk PRIMARY KEY AUTOINCREMENT,
+    monster_id INTEGER NOT NULL
+        CONSTRAINT monster_id_fk REFERENCES monster,
+    location_id INTEGER NOT NULL
+        CONSTRAINT location_id_fk REFERENCES location
+);
+
+INSERT INTO monster_location (monster_id, location_id) VALUES
+((SELECT id FROM monster WHERE name = 'Bulbasaur'), (SELECT id FROM location WHERE name = 'Pallet Town')),
+((SELECT id FROM monster WHERE name = 'Charmander'), (SELECT id FROM location WHERE name = 'Pallet Town')),
+((SELECT id FROM monster WHERE name = 'Squirtle'), (SELECT id FROM location WHERE name = 'Pallet Town')),
+
+((SELECT id FROM monster WHERE name = 'Caterpie'), (SELECT id FROM location WHERE name = 'Route 2')),
+((SELECT id FROM monster WHERE name = 'Caterpie'), (SELECT id FROM location WHERE name = 'Route 24')),
+((SELECT id FROM monster WHERE name = 'Caterpie'), (SELECT id FROM location WHERE name = 'Route 25')),
+((SELECT id FROM monster WHERE name = 'Caterpie'), (SELECT id FROM location WHERE name = 'Viridian Forest')),
+
+((SELECT id FROM monster WHERE name = 'Metapod'), (SELECT id FROM location WHERE name = 'Route 24')),
+((SELECT id FROM monster WHERE name = 'Metapod'), (SELECT id FROM location WHERE name = 'Route 25')),
+((SELECT id FROM monster WHERE name = 'Metapod'), (SELECT id FROM location WHERE name = 'Viridian Forest')),
+
+((SELECT id FROM monster WHERE name = 'Weedle'), (SELECT id FROM location WHERE name = 'Route 2')),
+((SELECT id FROM monster WHERE name = 'Weedle'), (SELECT id FROM location WHERE name = 'Route 24')),
+((SELECT id FROM monster WHERE name = 'Weedle'), (SELECT id FROM location WHERE name = 'Route 25')),
+((SELECT id FROM monster WHERE name = 'Weedle'), (SELECT id FROM location WHERE name = 'Viridian Forest')),
+
+((SELECT id FROM monster WHERE name = 'Kakuna'), (SELECT id FROM location WHERE name = 'Route 24')),
+((SELECT id FROM monster WHERE name = 'Kakuna'), (SELECT id FROM location WHERE name = 'Route 25')),
+((SELECT id FROM monster WHERE name = 'Kakuna'), (SELECT id FROM location WHERE name = 'Viridian Forest')),
+
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 1')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 2')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 3')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 5')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 6')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 7')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 8')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 12')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 13')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 14')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 15')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 21')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 24')),
+((SELECT id FROM monster WHERE name = 'Pidgey'), (SELECT id FROM location WHERE name = 'Route 25')),
+
+((SELECT id FROM monster WHERE name = 'Pidgeotto'), (SELECT id FROM location WHERE name = 'Route 14')),
+((SELECT id FROM monster WHERE name = 'Pidgeotto'), (SELECT id FROM location WHERE name = 'Route 15')),
+((SELECT id FROM monster WHERE name = 'Pidgeotto'), (SELECT id FROM location WHERE name = 'Route 21')),
+
+((SELECT id FROM monster WHERE name = 'Rattata'), (SELECT id FROM location WHERE name = 'Route 1')),
+((SELECT id FROM monster WHERE name = 'Rattata'), (SELECT id FROM location WHERE name = 'Route 2')),
+((SELECT id FROM monster WHERE name = 'Rattata'), (SELECT id FROM location WHERE name = 'Route 4')),
+((SELECT id FROM monster WHERE name = 'Rattata'), (SELECT id FROM location WHERE name = 'Route 9')),
+((SELECT id FROM monster WHERE name = 'Rattata'), (SELECT id FROM location WHERE name = 'Route 16')),
+((SELECT id FROM monster WHERE name = 'Rattata'), (SELECT id FROM location WHERE name = 'Route 21')),
+((SELECT id FROM monster WHERE name = 'Rattata'), (SELECT id FROM location WHERE name = 'Route 22')),
+
+((SELECT id FROM monster WHERE name = 'Raticate'), (SELECT id FROM location WHERE name = 'Route 16')),
+((SELECT id FROM monster WHERE name = 'Raticate'), (SELECT id FROM location WHERE name = 'Route 17')),
+((SELECT id FROM monster WHERE name = 'Raticate'), (SELECT id FROM location WHERE name = 'Route 18')),
+((SELECT id FROM monster WHERE name = 'Raticate'), (SELECT id FROM location WHERE name = 'Route 21')),
+
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 3')),
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 4')),
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 9')),
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 10')),
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 11')),
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 16')),
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 17')),
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 18')),
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 22')),
+((SELECT id FROM monster WHERE name = 'Spearow'), (SELECT id FROM location WHERE name = 'Route 23')),
+
+((SELECT id FROM monster WHERE name = 'Fearow'), (SELECT id FROM location WHERE name = 'Route 17')),
+((SELECT id FROM monster WHERE name = 'Fearow'), (SELECT id FROM location WHERE name = 'Route 18')),
+((SELECT id FROM monster WHERE name = 'Fearow'), (SELECT id FROM location WHERE name = 'Route 23')),
+
+((SELECT id FROM monster WHERE name = 'Ekans'), (SELECT id FROM location WHERE name = 'Route 4')),
+((SELECT id FROM monster WHERE name = 'Ekans'), (SELECT id FROM location WHERE name = 'Route 8')),
+((SELECT id FROM monster WHERE name = 'Ekans'), (SELECT id FROM location WHERE name = 'Route 9')),
+((SELECT id FROM monster WHERE name = 'Ekans'), (SELECT id FROM location WHERE name = 'Route 10')),
+((SELECT id FROM monster WHERE name = 'Ekans'), (SELECT id FROM location WHERE name = 'Route 11')),
+((SELECT id FROM monster WHERE name = 'Ekans'), (SELECT id FROM location WHERE name = 'Route 23')),
+
+((SELECT id FROM monster WHERE name = 'Arbok'), (SELECT id FROM location WHERE name = 'Route 23')),
+((SELECT id FROM monster WHERE name = 'Arbok'), (SELECT id FROM location WHERE name = 'Cerulean Cave')),
+
+((SELECT id FROM monster WHERE name = 'Pikachu'), (SELECT id FROM location WHERE name = 'Viridian Forest')),
+((SELECT id FROM monster WHERE name = 'Pikachu'), (SELECT id FROM location WHERE name = 'Power Plant')),
+
+((SELECT id FROM monster WHERE name = 'Raichu'), (SELECT id FROM location WHERE name = 'Viridian Forest')),
+((SELECT id FROM monster WHERE name = 'Raichu'), (SELECT id FROM location WHERE name = 'Power Plant')),
+
+((SELECT id FROM monster WHERE name = 'Sandshrew'), (SELECT id FROM location WHERE name = 'Route 4')),
+((SELECT id FROM monster WHERE name = 'Sandshrew'), (SELECT id FROM location WHERE name = 'Route 8')),
+((SELECT id FROM monster WHERE name = 'Sandshrew'), (SELECT id FROM location WHERE name = 'Route 9')),
+((SELECT id FROM monster WHERE name = 'Sandshrew'), (SELECT id FROM location WHERE name = 'Route 10')),
+((SELECT id FROM monster WHERE name = 'Sandshrew'), (SELECT id FROM location WHERE name = 'Route 11')),
+((SELECT id FROM monster WHERE name = 'Sandshrew'), (SELECT id FROM location WHERE name = 'Route 23')),
+
+((SELECT id FROM monster WHERE name = 'Sandslash'), (SELECT id FROM location WHERE name = 'Route 23')),
+((SELECT id FROM monster WHERE name = 'Sandslash'), (SELECT id FROM location WHERE name = 'Cerulean Cave')),
+
+((SELECT id FROM monster WHERE name = 'Nidoran♀'), (SELECT id FROM location WHERE name = 'Route 22')),
+((SELECT id FROM monster WHERE name = 'Nidoran♀'), (SELECT id FROM location WHERE name = 'Safari Zone')),
+((SELECT id FROM monster WHERE name = 'Nidoran♀'), (SELECT id FROM location WHERE name = 'Underground Path (North)')),
+((SELECT id FROM monster WHERE name = 'Nidoran♀'), (SELECT id FROM location WHERE name = 'Underground Path (South)')),
+
+((SELECT id FROM monster WHERE name = 'Nidorina'), (SELECT id FROM location WHERE name = 'Safari Zone')),
+((SELECT id FROM monster WHERE name = 'Nidorina'), (SELECT id FROM location WHERE name = 'Celadon City')),
+((SELECT id FROM monster WHERE name = 'Nidorina'), (SELECT id FROM location WHERE name = 'Route 11'))
+
+;

--- a/src/Config/routing.php
+++ b/src/Config/routing.php
@@ -1,6 +1,7 @@
 <?php
 
 use Slim\App;
+use zbtnot\MonsterDb\Controller\LocationController;
 use zbtnot\MonsterDb\Controller\MonsterController;
 use zbtnot\MonsterDb\Controller\MoveController;
 
@@ -10,6 +11,7 @@ return function (App $app) {
     $app->get('/api/monster/{id}', [MonsterController::class, 'fetchMonsterByDexId']);
     $app->get('/api/move', [MoveController::class, 'fetchMovesAction']);
     $app->get('/api/move/{id}', [MoveController::class, 'fetchMoveByIdAction']);
+    $app->get('/api/location', [LocationController::class, 'fetchLocationsAction']);
 
     // index action is the last route so non-api calls can fall-through to vue-router
     $app->get('/{path:.*}', [MonsterController::class, 'indexAction']);

--- a/src/Controller/LocationController.php
+++ b/src/Controller/LocationController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace zbtnot\MonsterDb\Controller;
+
+use zbtnot\MonsterDb\Http\JsonResponse;
+use zbtnot\MonsterDb\Model\Location;
+use zbtnot\MonsterDb\Repository\LocationRepository;
+
+class LocationController extends Controller
+{
+    public function __construct(private readonly LocationRepository $locationRepository)
+    {
+    }
+
+    public function fetchLocationsAction(): JsonResponse
+    {
+        $locations = [];
+        try {
+            $locations = $this->locationRepository->fetchLocations();
+        } catch (\Throwable $e) {
+            $this->logger->error($e->getMessage());
+        } finally {
+            return new JsonResponse($locations);
+        }
+    }
+}

--- a/src/Model/DetailedMonster.php
+++ b/src/Model/DetailedMonster.php
@@ -25,6 +25,9 @@ class DetailedMonster implements \JsonSerializable
     /** @var array<int, EvolutionMonster[]> */
     private $evolutions;
 
+    /** @var Location[] */
+    private array $locations;
+
     public function __construct(Monster $monster)
     {
         $this->monster = $monster;
@@ -111,6 +114,20 @@ class DetailedMonster implements \JsonSerializable
         return $this;
     }
 
+    /** @return Location[] */
+    public function getLocations(): array
+    {
+        return $this->locations;
+    }
+
+    /** @param Location[] $locations */
+    public function setLocations(array $locations): self
+    {
+        $this->locations = $locations;
+
+        return $this;
+    }
+
     public function jsonSerialize(): array
     {
         $fields = [
@@ -120,6 +137,7 @@ class DetailedMonster implements \JsonSerializable
             'cryPath' => $this->getCryPath(),
             'moves' => $this->getMoves(),
             'evolutions' => $this->getEvolutions(),
+            'locations' => $this->getLocations(),
         ];
 
         return array_merge($fields, $this->monster->jsonSerialize());

--- a/src/Model/Location.php
+++ b/src/Model/Location.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace zbtnot\MonsterDb\Model;
+
+class Location implements \JsonSerializable
+{
+    private string $name;
+    private int $x;
+    private int $y;
+    private int $width;
+    private int $height;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getX(): int
+    {
+        return $this->x;
+    }
+
+    public function setX(int $x): self
+    {
+        $this->x = $x;
+
+        return $this;
+    }
+
+    public function getY(): int
+    {
+        return $this->y;
+    }
+
+    public function setY(int $y): self
+    {
+        $this->y = $y;
+
+        return $this;
+    }
+
+    public function getWidth(): int
+    {
+        return $this->width;
+    }
+
+    public function setWidth(int $width): self
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    public function getHeight(): int
+    {
+        return $this->height;
+    }
+
+    public function setHeight(int $height): self
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'name' => $this->getName(),
+            'x' => $this->getX(),
+            'y' => $this->getY(),
+            'width' => $this->getWidth(),
+            'height' => $this->getHeight(),
+        ];
+    }
+}

--- a/src/Repository/LocationRepository.php
+++ b/src/Repository/LocationRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace zbtnot\MonsterDb\Repository;
+
+use zbtnot\MonsterDb\Model\Location;
+
+class LocationRepository extends Repository
+{
+    /** @return Location[] */
+    public function fetchLocations(): array
+    {
+        $sql = <<<SQL
+            SELECT 
+                name,
+                x,
+                y,
+                width,
+                height
+            FROM location;
+        SQL;
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute();
+        $locations = $stmt->fetchAll();
+
+        $mapper = fn(array $location) => (new Location())
+            ->setName($location['name'])
+            ->setX($location['x'])
+            ->setY($location['y'])
+            ->setWidth($location['width'])
+            ->setHeight($location['height']);
+
+        return array_map($mapper, $locations);
+    }
+
+    /** @return Location[] */
+    public function findLocationsByMonsterId(int $monsterId): array
+    {
+        $sql = <<<SQL
+            SELECT 
+                name,
+                x,
+                y,
+                width,
+                height
+            FROM location
+            INNER JOIN monster_location ml on location.id = ml.location_id
+            WHERE ml.monster_id = :id;
+        SQL;
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([':id' => $monsterId]);
+        $locations = $stmt->fetchAll();
+
+        $mapper = fn(array $location) => (new Location())
+            ->setName($location['name'])
+            ->setX($location['x'])
+            ->setY($location['y'])
+            ->setWidth($location['width'])
+            ->setHeight($location['height']);
+
+        return array_map($mapper, $locations);
+    }
+}

--- a/src/Service/DetailedMonsterService.php
+++ b/src/Service/DetailedMonsterService.php
@@ -9,6 +9,7 @@ use zbtnot\MonsterDb\Model\Monster;
 use zbtnot\MonsterDb\Repository\CryRepository;
 use zbtnot\MonsterDb\Repository\EvolutionRepository;
 use zbtnot\MonsterDb\Repository\GraphicRepository;
+use zbtnot\MonsterDb\Repository\LocationRepository;
 use zbtnot\MonsterDb\Repository\MonsterRepository;
 use zbtnot\MonsterDb\Repository\MoveRepository;
 use zbtnot\MonsterDb\Repository\TypeRepository;
@@ -23,6 +24,7 @@ class DetailedMonsterService
         private readonly MonsterRepository $monsterRepository,
         private readonly CryRepository $cryRepository,
         private readonly EvolutionRepository $evolutionRepository,
+        private readonly LocationRepository $locationRepository,
     ) {
     }
 
@@ -33,6 +35,7 @@ class DetailedMonsterService
         $sprite = $this->illustrationRepository->fetchSpriteByMonsterId($monster->getId());
         $cry = $this->cryRepository->fetchCryByMonsterId($monster->getId());
         $moves = $this->moveRepository->getMovesByMonsterId($monster->getId());
+        $locations = $this->locationRepository->findLocationsByMonsterId($monster->getId());
 
         $evolutions = $this->monsterRepository->fetchMonstersFromEvolutionTreeByMonsterId($monster->getId());
         foreach ($evolutions as &$evolutionList) {
@@ -54,6 +57,7 @@ class DetailedMonsterService
             ->setSpritePath($sprite)
             ->setCryPath($cry)
             ->setMoves($moves)
-            ->setEvolutions($evolutions);
+            ->setEvolutions($evolutions)
+            ->setLocations($locations);
     }
 }

--- a/test/Service/DetailedMonsterServiceTest.php
+++ b/test/Service/DetailedMonsterServiceTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use zbtnot\MonsterDb\Model\DetailedMonster;
 use zbtnot\MonsterDb\Model\EvolutionMonster;
 use zbtnot\MonsterDb\Model\GraphicMonster;
+use zbtnot\MonsterDb\Model\Location;
 use zbtnot\MonsterDb\Model\Monster;
 use zbtnot\MonsterDb\Model\Move;
 use zbtnot\MonsterDb\Model\Requisite;
@@ -15,6 +16,7 @@ use zbtnot\MonsterDb\Model\Type;
 use zbtnot\MonsterDb\Repository\CryRepository;
 use zbtnot\MonsterDb\Repository\EvolutionRepository;
 use zbtnot\MonsterDb\Repository\GraphicRepository;
+use zbtnot\MonsterDb\Repository\LocationRepository;
 use zbtnot\MonsterDb\Repository\MonsterRepository;
 use zbtnot\MonsterDb\Repository\MoveRepository;
 use zbtnot\MonsterDb\Repository\TypeRepository;
@@ -34,6 +36,7 @@ class DetailedMonsterServiceTest extends TestCase
     private MockObject $monsterRepository;
     private MockObject $cryRepository;
     private MockObject $evolutionRepository;
+    private MockObject $locationRepository;
 
     private DetailedMonsterService $detailedMonsterService;
 
@@ -46,6 +49,7 @@ class DetailedMonsterServiceTest extends TestCase
         $this->monsterRepository = $this->createMock(MonsterRepository::class);
         $this->cryRepository = $this->createMock(CryRepository::class);
         $this->evolutionRepository = $this->createMock(EvolutionRepository::class);
+        $this->locationRepository = $this->createMock(LocationRepository::class);
 
         $this->detailedMonsterService = new DetailedMonsterService(
             $this->typeRepository,
@@ -55,6 +59,7 @@ class DetailedMonsterServiceTest extends TestCase
             $this->monsterRepository,
             $this->cryRepository,
             $this->evolutionRepository,
+            $this->locationRepository,
         );
     }
 
@@ -71,6 +76,7 @@ class DetailedMonsterServiceTest extends TestCase
         $evolutions = [$monster->getId() => [(new Monster())->setEvolutionHowId(0)]];
         $illustratedEvolutions = [new GraphicMonster($evolutions[$monster->getId()][0])];
         $cry = 'bubl.flac';
+        $locations = [new Location()];
 
         $evolutionRequisite = (new Requisite())->setType(RequisiteType::LEVEL_UP)->setContents(0);
         $evolutionMonsters = array_map(function (GraphicMonster $graphicMonster) use ($evolutionRequisite) {
@@ -83,7 +89,8 @@ class DetailedMonsterServiceTest extends TestCase
             ->setEvolutions([$monster->getId() => $evolutionMonsters])
             ->setIllustrationPath($illustration)
             ->setSpritePath($sprite)
-            ->setCryPath($cry);
+            ->setCryPath($cry)
+            ->setLocations($locations);
 
         $this->typeRepository
             ->expects($this->once())
@@ -132,6 +139,12 @@ class DetailedMonsterServiceTest extends TestCase
             ->method('fetchRequisiteByEvolutionId')
             ->with($monster->getEvolutionHowId())
             ->willReturn($evolutionRequisite);
+
+        $this->locationRepository
+            ->expects($this->once())
+            ->method('findLocationsByMonsterId')
+            ->with($monster->getId())
+            ->willReturn($locations);
 
         $result = $this->detailedMonsterService->fetchDetailedMonsterFromMonster($monster);
         $this->assertEquals($detailedMonster, $result);


### PR DESCRIPTION
- New endpoint `/api/location`
- New tables 
  - `location`
  - `monster_location`
- new asset (gen one map)
- new card for Monster Details
- Data scoped to first 30 monsters, will divvy up the remaining next

![image](https://github.com/zbtnot/monsterdb/assets/12577217/67e0afa2-3c1d-4bfc-a256-be86b3d5bf6f)
