### PR TITLE
Add hurl testing for backend endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ logger:
 unit:
 	XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-html test-coverage
 
+hurl:
+	hurl --variable host=http://localhost:8080 --test test/hurl/*.hurl
+
 clean:
 	rm db.sqlite
 	rm -rf vendor

--- a/src/Controller/LocationController.php
+++ b/src/Controller/LocationController.php
@@ -2,21 +2,23 @@
 
 namespace zbtnot\MonsterDb\Controller;
 
+use Slim\Psr7\Request;
 use zbtnot\MonsterDb\Http\JsonResponse;
-use zbtnot\MonsterDb\Model\Location;
-use zbtnot\MonsterDb\Repository\LocationRepository;
+use zbtnot\MonsterDb\Service\LocationService;
 
 class LocationController extends Controller
 {
-    public function __construct(private readonly LocationRepository $locationRepository)
+    public function __construct(private readonly LocationService $locationService)
     {
     }
 
-    public function fetchLocationsAction(): JsonResponse
+    public function fetchLocationsAction(Request $request): JsonResponse
     {
+        $limit = $request->getQueryParams()['count'] ?? null;
+        $offset = $request->getQueryParams()['offset'] ?? null;
         $locations = [];
         try {
-            $locations = $this->locationRepository->fetchLocations();
+            $locations = $this->locationService->fetchLocations($limit, $offset);
         } catch (\Throwable $e) {
             $this->logger->error($e->getMessage());
         } finally {

--- a/src/Controller/MoveController.php
+++ b/src/Controller/MoveController.php
@@ -16,10 +16,12 @@ class MoveController extends Controller
 
     public function fetchMovesAction(Request $request, Response $response): JsonResponse
     {
+        $limit = $request->getQueryParams()['count'] ?? null;
+        $offset = $request->getQueryParams()['offset'] ?? null;
         $status = StatusCodeInterface::STATUS_OK;
         $moves = [];
         try {
-            $moves = $this->moveService->fetchMoves();
+            $moves = $this->moveService->fetchMoves($limit, $offset);
         } catch (\Throwable $e) {
             $status = StatusCodeInterface::STATUS_BAD_REQUEST;
             $this->logger->error($e->getMessage());

--- a/src/Repository/LocationRepository.php
+++ b/src/Repository/LocationRepository.php
@@ -7,7 +7,7 @@ use zbtnot\MonsterDb\Model\Location;
 class LocationRepository extends Repository
 {
     /** @return Location[] */
-    public function fetchLocations(): array
+    public function fetchLocations(?int $limit, ?int $offset): array
     {
         $sql = <<<SQL
             SELECT 
@@ -16,10 +16,12 @@ class LocationRepository extends Repository
                 y,
                 width,
                 height
-            FROM location;
+            FROM location
         SQL;
+        $sql .= $this->generatePaginationString($limit, $offset);
+        $params = $this->generatePaginationParameters($limit, $offset);
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute();
+        $stmt->execute($params);
         $locations = $stmt->fetchAll();
 
         $mapper = fn(array $location) => (new Location())

--- a/src/Repository/MoveRepository.php
+++ b/src/Repository/MoveRepository.php
@@ -58,7 +58,7 @@ class MoveRepository extends Repository
     }
 
     /** @return Move[] */
-    public function getMoves(): array
+    public function getMoves(?int $limit, ?int $offset): array
     {
         $sql = <<<SQL
             SELECT
@@ -71,8 +71,10 @@ class MoveRepository extends Repository
             FROM move
             INNER JOIN type ON move.type_id = type.id
         SQL;
+        $sql .= $this->generatePaginationString($limit, $offset);
+        $params = $this->generatePaginationParameters($limit, $offset);
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute();
+        $stmt->execute($params);
 
         $moves = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         return array_map(function (array $move) {

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -8,4 +8,33 @@ abstract class Repository
 {
     #[Inject]
     protected \PDO $pdo;
+
+    protected function generatePaginationString(?int $limit, ?int $offset): string
+    {
+        $str = '';
+        if ($limit !== null) {
+            $str .= ' LIMIT :limit ';
+
+            if ($offset !== null) {
+                $str .= ' OFFSET :offset ';
+            }
+        }
+
+        return $str;
+    }
+
+    /** @return array<string,int> */
+    protected function generatePaginationParameters(?int $limit, ?int $offset): array
+    {
+        $arr = [];
+        if ($limit !== null) {
+            $arr[':limit'] = $limit;
+
+            if ($offset !== null) {
+                $arr[':offset'] = $offset;
+            }
+        }
+
+        return $arr;
+    }
 }

--- a/src/Service/LocationService.php
+++ b/src/Service/LocationService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace zbtnot\MonsterDb\Service;
+
+use zbtnot\MonsterDb\Model\Location;
+use zbtnot\MonsterDb\Repository\LocationRepository;
+
+class LocationService
+{
+    public function __construct(private readonly LocationRepository $locationRepository)
+    {
+    }
+
+    /** @return Location[] */
+    public function fetchLocations(?int $limit = null, ?int $offset = null): array
+    {
+        return $this->locationRepository->fetchLocations($limit, $offset);
+    }
+}

--- a/src/Service/MoveService.php
+++ b/src/Service/MoveService.php
@@ -19,9 +19,9 @@ class MoveService
     }
 
     /** @return Move[] */
-    public function fetchMoves(): array
+    public function fetchMoves(?int $limit = null, ?int $offset = null): array
     {
-        return $this->moveRepository->getMoves();
+        return $this->moveRepository->getMoves($limit, $offset);
     }
 
     public function fetchMoveById(int $id): Move

--- a/test/Service/LocationServiceTest.php
+++ b/test/Service/LocationServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace zbtnot\MonsterDb\Tests\Service;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use zbtnot\MonsterDb\Model\Location;
+use zbtnot\MonsterDb\Repository\LocationRepository;
+use zbtnot\MonsterDb\Service\LocationService;
+
+/**
+ * @coversDefaultClass zbtnot\MonsterDb\Service\LocationService
+ * @covers zbtnot\MonsterDb\Service\LocationService
+ */
+class LocationServiceTest extends TestCase
+{
+    private MockObject $locationRepository;
+    private LocationService $locationService;
+
+    protected function setUp(): void
+    {
+        $this->locationRepository = $this->createMock(LocationRepository::class);
+
+        $this->locationService = new LocationService($this->locationRepository);
+    }
+
+    public function testCanFetchLocations()
+    {
+        $location = (new Location())
+            ->setName('foo')
+            ->setX(0)
+            ->setY(0)
+            ->setWidth(1)
+            ->setHeight(1);
+        $this->locationRepository
+            ->method('fetchLocations')
+            ->with(1, 1)
+            ->willReturn([$location]);
+
+        $result = $this->locationService->fetchLocations(1, 1);
+        $this->assertEquals([$location], $result);
+    }
+}

--- a/test/hurl/api.hurl
+++ b/test/hurl/api.hurl
@@ -1,0 +1,72 @@
+GET {{host}}/api/monster
+[QueryStringParams]
+count: 1
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json"
+jsonpath "$.1.dexId" isInteger
+jsonpath "$.1.illustrationPath" isString
+jsonpath "$.1.name" isString
+jsonpath "$.1.height" exists
+jsonpath "$.1.weight" exists
+jsonpath "$.1.description" isString
+
+GET {{host}}/api/monster/1
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json"
+jsonpath "$.monster.types" exists
+jsonpath "$.monster.illustrationPath" isString
+jsonpath "$.monster.spritePath" isString
+jsonpath "$.monster.cryPath" isString
+jsonpath "$.monster.moves" exists
+jsonpath "$.monster.evolutions" exists
+jsonpath "$.monster.locations" exists
+jsonpath "$.monster.dexId" isInteger
+jsonpath "$.monster.name" isString
+jsonpath "$.monster.height" exists
+jsonpath "$.monster.weight" exists
+jsonpath "$.monster.description" isString
+
+GET {{host}}/api/move
+[QueryStringParams]
+count: 1
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json"
+jsonpath "$" count == 1
+jsonpath "$[0].id" isInteger
+jsonpath "$[0].name" isString
+jsonpath "$[0].pp" isInteger
+jsonpath "$[0].power" isInteger
+jsonpath "$[0].accuracy" isInteger
+jsonpath "$[0].type" isString
+jsonpath "$[0].requisite" exists
+
+GET {{host}}/api/move/1
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json"
+jsonpath "$.animations[0].path" isString
+jsonpath "$.animations[0].mimeType" isString
+jsonpath "$.monsters" exists
+jsonpath "$.id" isInteger
+jsonpath "$.name" isString
+jsonpath "$.pp" isInteger
+jsonpath "$.power" isInteger
+jsonpath "$.accuracy" isInteger
+jsonpath "$.type" isString
+jsonpath "$.requisite" exists
+
+GET {{host}}/api/location
+[QueryStringParams]
+count: 1
+HTTP 200
+[Asserts]
+header "Content-Type" == "application/json"
+jsonpath "$[0].name" isString
+jsonpath "$[0].x" isInteger
+jsonpath "$[0].y" isInteger
+jsonpath "$[0].width" isInteger
+jsonpath "$[0].height" isInteger
+


### PR DESCRIPTION
- Adds [hurl](https://hurl.dev/) for testing the backend endpoints at `/api/`
- New make target `hurl`, configured for the docker env
- Tweaks to the endpoints to enable pagination
  - This keeps the tests a bit more concise